### PR TITLE
Introduce incremental update of sorted nodes based on btree for batch allocation to improve scheduling performance

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.12
 require (
 	github.com/cloudera/yunikorn-scheduler-interface v0.0.0-20190926162348-e1f0f8203763
 	github.com/creack/pty v1.1.9 // indirect
+	github.com/google/btree v1.0.0
 	github.com/google/go-cmp v0.3.1 // indirect
 	github.com/gorilla/mux v1.7.3
 	github.com/kr/pretty v0.1.0 // indirect
@@ -13,6 +14,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/pkg/errors v0.8.1 // indirect
 	github.com/prometheus/client_golang v1.1.0
+	github.com/prometheus/common v0.6.0
 	github.com/satori/go.uuid v1.2.0
 	github.com/stretchr/testify v1.3.0
 	go.uber.org/atomic v1.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,8 @@ github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/google/btree v1.0.0 h1:0udJVsspx3VBr5FwtLhQQtuAsVc79tTq0ocGIPAU6qo=
+github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=

--- a/pkg/cache/node_info.go
+++ b/pkg/cache/node_info.go
@@ -96,7 +96,9 @@ func (ni *NodeInfo) GetAllocatedResource() *resources.Resource {
 func (ni *NodeInfo) GetAvailableResource() *resources.Resource {
     ni.lock.RLock()
     defer ni.lock.RUnlock()
-
+    if ni.availableResource == nil {
+        ni.availableResource = resources.NewResource()
+    }
     return ni.availableResource.Clone()
 }
 

--- a/pkg/cache/node_info.go
+++ b/pkg/cache/node_info.go
@@ -96,6 +96,7 @@ func (ni *NodeInfo) GetAllocatedResource() *resources.Resource {
 func (ni *NodeInfo) GetAvailableResource() *resources.Resource {
     ni.lock.RLock()
     defer ni.lock.RUnlock()
+
     if ni.availableResource == nil {
         ni.availableResource = resources.NewResource()
     }

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -107,7 +107,7 @@ func newSingleAllocationProposal(alloc *SchedulingAllocation) *cacheevent.Alloca
 // Internal start scheduling service
 func (m *Scheduler) internalSchedule() {
     for {
-        m.singleStepSchedule(256, &preemptionParameters{
+        m.singleStepSchedule(16, &preemptionParameters{
             crossQueuePreemption: false,
             blacklistedRequest: make(map[string]bool),
         })

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -107,7 +107,7 @@ func newSingleAllocationProposal(alloc *SchedulingAllocation) *cacheevent.Alloca
 // Internal start scheduling service
 func (m *Scheduler) internalSchedule() {
     for {
-        m.singleStepSchedule(16, &preemptionParameters{
+        m.singleStepSchedule(256, &preemptionParameters{
             crossQueuePreemption: false,
             blacklistedRequest: make(map[string]bool),
         })

--- a/pkg/scheduler/sorters_test.go
+++ b/pkg/scheduler/sorters_test.go
@@ -180,12 +180,20 @@ func TestQueueGuaranteedResourceNotSet(t *testing.T) {
 }
 
 func TestSortNodesMin(t *testing.T) {
+	testSortNodesMin(t, &SliceBasedNodeSorter{})
+	testSortNodesMin(t, &BtreeBasedNodeSorter{})
+}
+
+func testSortNodesMin(t *testing.T, nodeSorter NodeSorter) {
 	// nil or empty list cannot panic
-	SortNodes(nil, MinAvailableResources)
+	nodeSorter.Init(nil, MinAvailableResources)
+	nodeSorter.GetSortedSchedulingNodes()
 	list := make([]*SchedulingNode, 0)
-	SortNodes(list, MinAvailableResources)
+	nodeSorter.Init(list, MinAvailableResources)
+	nodeSorter.GetSortedSchedulingNodes()
 	list = append(list, NewSchedulingNode(cache.NewNodeForSort("node-nil", nil)))
-	SortNodes(list, MinAvailableResources)
+	nodeSorter.Init(list, MinAvailableResources)
+	nodeSorter.GetSortedSchedulingNodes()
 
 	// stable sort is used so equal resources stay were they were
 	res := resources.NewResourceFromMap(map[string]resources.Quantity{
@@ -201,7 +209,8 @@ func TestSortNodesMin(t *testing.T) {
 		list[i] = node
 	}
 	// nodes should come back in order 2 (100), 1 (200), 0 (300)
-	SortNodes(list, MinAvailableResources)
+	nodeSorter.Init(list, MinAvailableResources)
+	list = nodeSorter.GetSortedSchedulingNodes()
 	assertNodeList(t, list, []int{2,1,0})
 
 	// change node-1 on place 1 in the slice to have no res
@@ -209,7 +218,8 @@ func TestSortNodesMin(t *testing.T) {
 		cache.NewNodeForSort("node-1", resources.Multiply(res, 0)),
 	)
 	// nodes should come back in order 1 (0), 2 (100), 0 (300)
-	SortNodes(list, MinAvailableResources)
+	nodeSorter.Init(list, MinAvailableResources)
+	list = nodeSorter.GetSortedSchedulingNodes()
 	assertNodeList(t, list, []int{2,0,1})
 
 	// change node-1 on place 0 in the slice to have 300 res
@@ -217,7 +227,8 @@ func TestSortNodesMin(t *testing.T) {
 		cache.NewNodeForSort("node-1", resources.Multiply(res, 3)),
 	)
 	// nodes should come back in order 2 (100), 1 (300), 0 (300)
-	SortNodes(list, MinAvailableResources)
+	nodeSorter.Init(list, MinAvailableResources)
+	list = nodeSorter.GetSortedSchedulingNodes()
 	assertNodeList(t, list, []int{2,1,0})
 
 	// change node-0 on place 2 in the slice to have -300 res
@@ -225,17 +236,26 @@ func TestSortNodesMin(t *testing.T) {
 		cache.NewNodeForSort("node-0", resources.Multiply(res, -3)),
 	)
 	// nodes should come back in order 0 (-300), 2 (100), 1 (300)
-	SortNodes(list, MinAvailableResources)
+	nodeSorter.Init(list, MinAvailableResources)
+	list = nodeSorter.GetSortedSchedulingNodes()
 	assertNodeList(t, list, []int{0,2,1})
 }
 
 func TestSortNodesMax(t *testing.T) {
+	testSortNodesMax(t, &SliceBasedNodeSorter{})
+	testSortNodesMax(t, &BtreeBasedNodeSorter{})
+}
+
+func testSortNodesMax(t *testing.T, nodeSorter NodeSorter) {
 	// nil or empty list cannot panic
-	SortNodes(nil, MaxAvailableResources)
+	nodeSorter.Init(nil, MaxAvailableResources)
+	assert.Equal(t, 0, len(nodeSorter.GetSortedSchedulingNodes()))
 	list := make([]*SchedulingNode, 0)
-	SortNodes(list, MaxAvailableResources)
+	nodeSorter.Init(list, MaxAvailableResources)
+	assert.Equal(t, 0, len(nodeSorter.GetSortedSchedulingNodes()))
 	list = append(list, NewSchedulingNode(cache.NewNodeForSort("node-nil", nil)))
-	SortNodes(list, MaxAvailableResources)
+	nodeSorter.Init(list, MaxAvailableResources)
+	assert.Equal(t, 1, len(nodeSorter.GetSortedSchedulingNodes()))
 
 	// stable sort is used so equal resources stay were they were
 	res := resources.NewResourceFromMap(map[string]resources.Quantity{
@@ -250,7 +270,8 @@ func TestSortNodesMax(t *testing.T) {
 		list[i] = node
 	}
 	// nodes should come back in order 2 (300), 1 (200), 0 (100)
-	SortNodes(list, MaxAvailableResources)
+	nodeSorter.Init(list, MaxAvailableResources)
+	list = nodeSorter.GetSortedSchedulingNodes()
 	assertNodeList(t, list, []int{2,1,0})
 
 	// change node-1 on place 1 in the slice to have no res
@@ -258,23 +279,37 @@ func TestSortNodesMax(t *testing.T) {
 		cache.NewNodeForSort("node-1", resources.Multiply(res, 0)),
 	)
 	// nodes should come back in order 2 (300), 0 (100), 1 (0)
-	SortNodes(list, MaxAvailableResources)
+	nodeSorter.Init(list, MaxAvailableResources)
+	list = nodeSorter.GetSortedSchedulingNodes()
 	assertNodeList(t, list, []int{1,2,0})
 
 	// change node-1 on place 2 in the slice to have 300 res
 	list[2] = NewSchedulingNode(
 		cache.NewNodeForSort("node-1", resources.Multiply(res, 3)),
 	)
-	// nodes should come back in order 2 (300), 1 (300), 0 (100)
-	SortNodes(list, MaxAvailableResources)
-	assertNodeList(t, list, []int{2,1,0})
 
-	// change node-2 on place 0 in the slice to have -300 res
-	list[0] = NewSchedulingNode(
-		cache.NewNodeForSort("node-2", resources.Multiply(res, -3)),
-	)
+	nodeSorter.Init(list, MaxAvailableResources)
+	list = nodeSorter.GetSortedSchedulingNodes()
+	switch nodeSorter.(type) {
+	case *SliceBasedNodeSorter:
+		// nodes should come back in order 2 (300), 1 (300), 0 (100)
+		assertNodeList(t, list, []int{2,1,0})
+		// change node-2 on place 0 in the slice to have -300 res
+		list[0] = NewSchedulingNode(
+			cache.NewNodeForSort("node-2", resources.Multiply(res, -3)),
+		)
+	case *BtreeBasedNodeSorter:
+		// nodes should come back in order 1 (300), 2 (300), 0 (100)
+		assertNodeList(t, list, []int{2,0,1})
+		// change node-2 on place 1 in the slice to have -300 res
+		list[1] = NewSchedulingNode(
+			cache.NewNodeForSort("node-2", resources.Multiply(res, -3)),
+		)
+	}
+
 	// nodes should come back in order 1 (300), 0 (100), 2 (-300)
-	SortNodes(list, MaxAvailableResources)
+	nodeSorter.Init(list, MaxAvailableResources)
+	list = nodeSorter.GetSortedSchedulingNodes()
 	assertNodeList(t, list, []int{1,0,2})
 }
 
@@ -373,7 +408,7 @@ func assertQueueList(t *testing.T, list []*SchedulingQueue, place []int) {
 // list of nodes and the location of the named nodes inside that list
 // place[0] defines the location of the node-0 in the list of nodes
 func assertNodeList(t *testing.T, list []*SchedulingNode, place []int) {
-	assert.Equal(t, "node-0", list[place[0]].NodeId)
+	assert.Equal(t, "node-0", list[place[0]].NodeId, )
 	assert.Equal(t, "node-1", list[place[1]].NodeId)
 	assert.Equal(t, "node-2", list[place[2]].NodeId)
 }

--- a/pkg/scheduler/tests/scheduler_perf_test.go
+++ b/pkg/scheduler/tests/scheduler_perf_test.go
@@ -170,8 +170,8 @@ partitions:
 
 func BenchmarkScheduling(b *testing.B) {
     tests := []struct{ numNodes, numPods int }{
-        {numNodes: 500, numPods: 10000},
-        {numNodes: 1000, numPods: 10000},
+        {numNodes: 500, numPods: 100000},
+        {numNodes: 1000, numPods: 100000},
         {numNodes: 2000, numPods: 10000},
         {numNodes: 5000, numPods: 10000},
     }

--- a/pkg/scheduler/tests/scheduler_smoke_test.go
+++ b/pkg/scheduler/tests/scheduler_smoke_test.go
@@ -1449,11 +1449,13 @@ partitions:
 
     waitForAllocations(mockRM, 9, 1000)
 
+    // node sequence may be different for different node sort policies
     totalNode1Resource := cache.GetPartition("[rm:123]default").GetNode("node-1:1234").GetAllocatedResource().Resources[resources.MEMORY]
-    assert.Equal(t, int(totalNode1Resource), 90)
-
     totalNode2Resource := cache.GetPartition("[rm:123]default").GetNode("node-2:1234").GetAllocatedResource().Resources[resources.MEMORY]
-    assert.Equal(t, int(totalNode2Resource), 0)
+    maxAllocatedMem := Max(int(totalNode1Resource), int(totalNode2Resource))
+    assert.Equal(t, maxAllocatedMem, 90)
+    minAllocatedMem := Min(int(totalNode1Resource), int(totalNode2Resource))
+    assert.Equal(t, minAllocatedMem, 0)
 }
 
 func TestFairnessAllocationForNodes(t *testing.T) {
@@ -1560,9 +1562,7 @@ partitions:
     waitForPendingResource(t, schedulerQueueA, 200, 1000)
     waitForPendingResourceForApplication(t, schedulingApp1, 200, 1000)
 
-    for i := 0; i < 20; i++ {
-        serviceContext.Scheduler.SingleStepScheduleAllocTest(1)
-    }
+    serviceContext.Scheduler.SingleStepScheduleAllocTest(20)
 
     // Verify all requests are satisfied
     waitForAllocations(mockRM, 20, 1000)

--- a/pkg/scheduler/tests/schedulertestutils.go
+++ b/pkg/scheduler/tests/schedulertestutils.go
@@ -25,6 +25,7 @@ import (
     "github.com/cloudera/yunikorn-core/pkg/scheduler"
     "github.com/cloudera/yunikorn-scheduler-interface/lib/go/si"
     "go.uber.org/zap"
+    "math"
     "sync"
     "testing"
     "time"
@@ -358,4 +359,30 @@ func newAddAppRequest(apps map[string]string) []*si.AddApplicationRequest {
         requests = append(requests, &request)
     }
     return requests
+}
+
+func Max(vars ...int) int {
+    if len(vars) == 0 {
+        return math.MinInt32
+    }
+    rst := vars[0]
+    for i := 1; i < len(vars); i++ {
+        if rst < vars[i] {
+            rst = vars[i]
+        }
+    }
+    return rst
+}
+
+func Min(vars ...int) int {
+    if len(vars) == 0 {
+        return math.MaxInt32
+    }
+    rst := vars[0]
+    for i := 1; i < len(vars); i++ {
+        if rst > vars[i] {
+            rst = vars[i]
+        }
+    }
+    return rst
 }


### PR DESCRIPTION
Currently the scheduling process will sort nodes for every single allocation, this leads to serious overhead and can make a great influence for a large cluster, performance effect can be show in follow graph according to the results of scheduling performance:
![image](https://user-images.githubusercontent.com/15521649/71142298-f2d59380-2251-11ea-8d3c-59dd50527e9f.png)
I would like to propose an efficient way to improve the scheduling performance, which sorts all nodes just once before doing batch allocation and updates the sorted nodes incrementally via adjusting one node changed in the latest allocation and keeping others unchanged. This approach is applicable when we expect that once batch allocation is momentary so that node resource may not change beyond the scheduling process. In this way, scheduling performance can be enhanced at least 900% as shown in next graph.

Updates:
 * Add NodeSorter interface and two implements based on slice and btree structures.
   * SliceBasedNodeSorter is the original approach based on slice.
   * BtreeBasedNodeSorter is based on btree which provides an in-memory B-Tree implementation for Go and holds the Apache license (more details pls refer to https://github.com/google/btree ).
 * Update the size of batch allocation from 16 to 256 according to the experiences of scheduling performance test, it can make a great influence on the scheduling performance for SliceBasedNodeSorter which can be shown in next graph which describes performance with different batch size: performance is more better as the batch size grow at the beginning and after 256 there's few changes.
![image](https://user-images.githubusercontent.com/15521649/71144277-75615180-2258-11ea-9b56-6179b8f2e46d.png)

 * UTs
   * Update sorter_test.go to test both NodeSorter implements.
   * Update scheduler_perf_test.go to make the results more accurate via enhancing expected allocation number from 10w to 100w for small-scale cluster with 500 or 1000 nodes.
   * Update scheduler_smoke_test.go to fit for this PR.
 * Update node_info.go#GetAvailableResource is to make UT correct since we may test a node whose availableResource is nil in sorters_test.go#TestSortNodesMin/TestSortNodesMax

@yangwwei @wilfred-s  could you pls help to review this PR? Thanks.