### PR TITLE
fix a scheduler deadlock 

### DIFF
--- a/pkg/cache/node_info.go
+++ b/pkg/cache/node_info.go
@@ -103,6 +103,12 @@ func (ni *NodeInfo) GetAvailableResource() *resources.Resource {
 	return ni.availableResource.Clone()
 }
 
+func (ni *NodeInfo) GetCapacity() *resources.Resource {
+	ni.lock.RLock()
+	defer ni.lock.RUnlock()
+	return ni.totalResource.Clone()
+}
+
 // Return the allocation based on the uuid of the allocation.
 // returns nil if the allocation is not found
 func (ni *NodeInfo) GetAllocation(uuid string) *AllocationInfo {

--- a/pkg/cache/partition_info.go
+++ b/pkg/cache/partition_info.go
@@ -794,6 +794,12 @@ func (pi *PartitionInfo) GetApplications() []*ApplicationInfo {
 	return appList
 }
 
+func (pi *PartitionInfo) GetNodes() map[string]*NodeInfo {
+	pi.RLock()
+	defer pi.RUnlock()
+	return pi.nodes
+}
+
 // Get the queue from the structure based on the fully qualified name.
 // Wrapper around the unlocked version getQueue()
 func (pi *PartitionInfo) GetQueue(name string) *QueueInfo {

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -292,8 +292,21 @@ func (s *Scheduler) recoverExistingAllocations(existingAllocations []*si.Allocat
 				zap.Error(err))
 		}
 
-		// recover allocation in cache
-		s.eventHandlers.CacheEventHandler.HandleEvent(alloc)
+		// ask cache to sync up
+		s.eventHandlers.CacheEventHandler.HandleEvent(&cacheevent.AllocationProposalBundleEvent{
+			AllocationProposals: []*commonevents.AllocationProposal{
+				{
+					NodeID:            alloc.NodeID,
+					ApplicationID:     alloc.ApplicationID,
+					QueueName:         alloc.QueueName,
+					AllocatedResource: resources.NewResourceFromProto(alloc.ResourcePerAlloc),
+					AllocationKey:     alloc.AllocationKey,
+					Priority:          alloc.Priority,
+					PartitionName:     alloc.PartitionName,
+				},
+			},
+			PartitionName: alloc.PartitionName,
+		})
 	}
 }
 

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -292,21 +292,21 @@ func (s *Scheduler) recoverExistingAllocations(existingAllocations []*si.Allocat
 				zap.Error(err))
 		}
 
-		// ask cache to sync up
-		s.eventHandlers.CacheEventHandler.HandleEvent(&cacheevent.AllocationProposalBundleEvent{
-			AllocationProposals: []*commonevents.AllocationProposal{
-				{
-					NodeID:            alloc.NodeID,
-					ApplicationID:     alloc.ApplicationID,
-					QueueName:         alloc.QueueName,
-					AllocatedResource: resources.NewResourceFromProto(alloc.ResourcePerAlloc),
-					AllocationKey:     alloc.AllocationKey,
-					Priority:          alloc.Priority,
-					PartitionName:     common.GetNormalizedPartitionName(alloc.PartitionName, rmID),
-				},
-			},
-			PartitionName: common.GetNormalizedPartitionName(alloc.PartitionName, rmID),
-		})
+		// // ask cache to sync up
+		// s.eventHandlers.CacheEventHandler.HandleEvent(&cacheevent.AllocationProposalBundleEvent{
+		// 	AllocationProposals: []*commonevents.AllocationProposal{
+		// 		{
+		// 			NodeID:            alloc.NodeID,
+		// 			ApplicationID:     alloc.ApplicationID,
+		// 			QueueName:         alloc.QueueName,
+		// 			AllocatedResource: resources.NewResourceFromProto(alloc.ResourcePerAlloc),
+		// 			AllocationKey:     alloc.AllocationKey,
+		// 			Priority:          alloc.Priority,
+		// 			PartitionName:     common.GetNormalizedPartitionName(alloc.PartitionName, rmID),
+		// 		},
+		// 	},
+		// 	PartitionName: common.GetNormalizedPartitionName(alloc.PartitionName, rmID),
+		// })
 	}
 }
 

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -291,22 +291,6 @@ func (s *Scheduler) recoverExistingAllocations(existingAllocations []*si.Allocat
 			log.Logger().Error("app recovery failed to confirm allocation proposal",
 				zap.Error(err))
 		}
-
-		// // ask cache to sync up
-		// s.eventHandlers.CacheEventHandler.HandleEvent(&cacheevent.AllocationProposalBundleEvent{
-		// 	AllocationProposals: []*commonevents.AllocationProposal{
-		// 		{
-		// 			NodeID:            alloc.NodeID,
-		// 			ApplicationID:     alloc.ApplicationID,
-		// 			QueueName:         alloc.QueueName,
-		// 			AllocatedResource: resources.NewResourceFromProto(alloc.ResourcePerAlloc),
-		// 			AllocationKey:     alloc.AllocationKey,
-		// 			Priority:          alloc.Priority,
-		// 			PartitionName:     common.GetNormalizedPartitionName(alloc.PartitionName, rmID),
-		// 		},
-		// 	},
-		// 	PartitionName: common.GetNormalizedPartitionName(alloc.PartitionName, rmID),
-		// })
 	}
 }
 

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -291,6 +291,9 @@ func (s *Scheduler) recoverExistingAllocations(existingAllocations []*si.Allocat
 			log.Logger().Error("app recovery failed to confirm allocation proposal",
 				zap.Error(err))
 		}
+
+		// recover allocation in cache
+		s.eventHandlers.CacheEventHandler.HandleEvent(alloc)
 	}
 }
 

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -302,10 +302,10 @@ func (s *Scheduler) recoverExistingAllocations(existingAllocations []*si.Allocat
 					AllocatedResource: resources.NewResourceFromProto(alloc.ResourcePerAlloc),
 					AllocationKey:     alloc.AllocationKey,
 					Priority:          alloc.Priority,
-					PartitionName:     alloc.PartitionName,
+					PartitionName:     common.GetNormalizedPartitionName(alloc.PartitionName, rmID),
 				},
 			},
-			PartitionName: alloc.PartitionName,
+			PartitionName: common.GetNormalizedPartitionName(alloc.PartitionName, rmID),
 		})
 	}
 }

--- a/pkg/scheduler/scheduling_application.go
+++ b/pkg/scheduler/scheduling_application.go
@@ -374,7 +374,7 @@ func (sa *SchedulingApplication) canAskReserve(ask *schedulingAllocationAsk) boo
 func (sa *SchedulingApplication) sortRequests(ascending bool) {
 	sa.sortedRequests = nil
 	for _, request := range sa.requests {
-		if request.pendingRepeatAsk == 0 {
+		if request.getPendingAskRepeat() == 0 {
 			continue
 		}
 		sa.sortedRequests = append(sa.sortedRequests, request)

--- a/pkg/webservice/dao/node_info.go
+++ b/pkg/webservice/dao/node_info.go
@@ -1,0 +1,35 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package dao
+
+type NodesDAOInfo struct {
+	PartitionName string         `json:"partitionName"`
+	Nodes         []*NodeDAOInfo `json:"nodesInfo"`
+}
+
+type NodeDAOInfo struct {
+	NodeID      string               `json:"nodeID"`
+	HostName    string               `json:"hostName"`
+	RackName    string               `json:"RackName"`
+	Capacity    string               `json:"capacity"`
+	Allocated   string               `json:"allocated"`
+	Available   string               `json:"available"`
+	Allocations []*AllocationDAOInfo `json:"allocations"`
+	Schedulable bool                 `json:"schedulable"`
+}

--- a/pkg/webservice/routes.go
+++ b/pkg/webservice/routes.go
@@ -53,6 +53,12 @@ var routes = Routes{
 		"/ws/v1/apps",
 		GetApplicationsInfo,
 	},
+	Route{
+		"Scheduler",
+		"GET",
+		"/ws/v1/nodes",
+		GetNodesInfo,
+	},
 
 	// endpoint to retrieve goroutines info
 	Route{


### PR DESCRIPTION
looks like we are having a deadlock situation when
1. scheduler is running the `trySchedule` loop
2. scheduler is trying to recover some existing allocations, calling `scheduling_application#recoverOnNode`

in the 1st call, it always tries to acquire the queue's lock, then app's lock;
in the 2nd call, it tries to acquire the app's lock then queue's lock

then it's easy to hit deadlock when they are running concurrently.