### PR TITLE
[YUNIKORN-6] Deadlock in the scheduler when restoring a node with allocations

### DIFF
--- a/pkg/cache/cachetestutils.go
+++ b/pkg/cache/cachetestutils.go
@@ -78,3 +78,10 @@ func newNodeForTest(nodeID string, totalResource, availResource *resources.Resou
 
 	return node
 }
+
+// Utility function to allow tests to set the guaranteed resource that is not exported
+func SetGuaranteedResource(info *QueueInfo, res *resources.Resource) {
+	if info != nil {
+		info.guaranteedResource = res
+	}
+}

--- a/pkg/cache/initializer_test.go
+++ b/pkg/cache/initializer_test.go
@@ -420,10 +420,10 @@ partitions:
 	if len(testQueue.Properties) != 1 {
 		t.Errorf("Failed parsing the properties on test queue in default partition")
 	}
-	if testQueue.GuaranteedResource.Resources["memory"] != 100 {
+	if testQueue.GetGuaranteedResource().Resources["memory"] != 100 {
 		t.Errorf("Failed parsing GuaranteedResource settings on test queue in default partition")
 	}
-	if testQueue.maxResource.Resources["vcore"] != 20 {
+	if testQueue.GetMaxResource().Resources["vcore"] != 20 {
 		t.Errorf("Failed parsing maxResource settings on test queue in default partition")
 	}
 }

--- a/pkg/cache/partition_info.go
+++ b/pkg/cache/partition_info.go
@@ -730,10 +730,10 @@ func (pi *PartitionInfo) GetQueueInfos() []dao.QueueDAOInfo {
 
 	info := dao.QueueDAOInfo{}
 	info.QueueName = pi.Root.Name
-	info.Status = "RUNNING"
+	info.Status = pi.Root.stateMachine.Current()
 	info.Capacities = dao.QueueCapacity{
-		Capacity:        checkAndSetResource(pi.Root.GuaranteedResource),
-		MaxCapacity:     checkAndSetResource(pi.Root.maxResource),
+		Capacity:        checkAndSetResource(pi.Root.GetGuaranteedResource()),
+		MaxCapacity:     checkAndSetResource(pi.Root.GetMaxResource()),
 		UsedCapacity:    checkAndSetResource(pi.Root.GetAllocatedResource()),
 		AbsUsedCapacity: "20",
 	}
@@ -749,17 +749,17 @@ func (pi *PartitionInfo) GetQueueInfos() []dao.QueueDAOInfo {
 // map status to the draining flag
 func GetChildQueueInfos(info *QueueInfo) []dao.QueueDAOInfo {
 	var infos []dao.QueueDAOInfo
-	for _, v := range info.children {
+	for _, child := range info.children {
 		queue := dao.QueueDAOInfo{}
-		queue.QueueName = v.Name
-		queue.Status = "RUNNING"
+		queue.QueueName = child.Name
+		queue.Status = child.stateMachine.Current()
 		queue.Capacities = dao.QueueCapacity{
-			Capacity:        checkAndSetResource(v.GuaranteedResource),
-			MaxCapacity:     checkAndSetResource(v.maxResource),
-			UsedCapacity:    checkAndSetResource(v.GetAllocatedResource()),
+			Capacity:        checkAndSetResource(child.GetGuaranteedResource()),
+			MaxCapacity:     checkAndSetResource(child.GetMaxResource()),
+			UsedCapacity:    checkAndSetResource(child.GetAllocatedResource()),
 			AbsUsedCapacity: "20",
 		}
-		queue.ChildQueues = GetChildQueueInfos(v)
+		queue.ChildQueues = GetChildQueueInfos(child)
 		infos = append(infos, queue)
 	}
 

--- a/pkg/scheduler/partition_manager.go
+++ b/pkg/scheduler/partition_manager.go
@@ -90,7 +90,7 @@ func (manager partitionManager) cleanQueues(schedulingQueue *SchedulingQueue) {
 			zap.String("queueName", schedulingQueue.Name),
 			zap.String("partitionName", manager.psc.Name))
 		// make sure the queue is empty
-		if len(schedulingQueue.applications) == 0 {
+		if schedulingQueue.isEmpty() {
 			// remove the cached queue, if not empty there is a problem since we have no applications left.
 			if schedulingQueue.QueueInfo.RemoveQueue() {
 				// all OK update the queue hierarchy and partition
@@ -109,7 +109,7 @@ func (manager partitionManager) cleanQueues(schedulingQueue *SchedulingQueue) {
 			}
 		} else {
 			// TODO time out waiting for draining and removal
-			log.Logger().Debug("failed to remove scheduling queue due to existing assigned apps",
+			log.Logger().Debug("failed to remove scheduling queue due to existing assigned apps or leaf queues",
 				zap.String("schedulingQueue", schedulingQueue.Name),
 				zap.String("partitionName", manager.psc.Name))
 		}

--- a/pkg/scheduler/preemptor.go
+++ b/pkg/scheduler/preemptor.go
@@ -59,7 +59,7 @@ type queuePreemptCalcResource struct {
 }
 
 func (m *queuePreemptCalcResource) initFromSchedulingQueue(queue *SchedulingQueue) {
-	m.guaranteed = queue.QueueInfo.GuaranteedResource
+	m.guaranteed = queue.QueueInfo.GetGuaranteedResource()
 	m.used = queue.QueueInfo.GetAllocatedResource()
 	m.pending = queue.GetPendingResource()
 	m.max = queue.QueueInfo.GetMaxResource()

--- a/pkg/scheduler/scheduling_application.go
+++ b/pkg/scheduler/scheduling_application.go
@@ -286,7 +286,7 @@ func (sa *SchedulingApplication) reserve(node *SchedulingNode, ask *schedulingAl
 		return fmt.Errorf("reservation creation failed ask %s not found on appID %s", allocKey, sa.ApplicationInfo.ApplicationID)
 	}
 	if !sa.canAskReserve(ask) {
-		return fmt.Errorf("reservation of ask exceeds pending repeat, pending ask repeat %d", ask.pendingRepeatAsk)
+		return fmt.Errorf("reservation of ask exceeds pending repeat, pending ask repeat %d", ask.getPendingAskRepeat())
 	}
 	// check if we can reserve the node before reserving on the app
 	if err := node.reserve(sa, ask); err != nil {
@@ -372,7 +372,7 @@ func (sa *SchedulingApplication) canAskReserve(ask *schedulingAllocationAsk) boo
 func (sa *SchedulingApplication) sortRequests(ascending bool) {
 	sa.sortedRequests = nil
 	for _, request := range sa.requests {
-		if request.pendingRepeatAsk == 0 {
+		if request.getPendingAskRepeat() == 0 {
 			continue
 		}
 		sa.sortedRequests = append(sa.sortedRequests, request)
@@ -415,7 +415,7 @@ func (sa *SchedulingApplication) tryReservedAllocate(headRoom *resources.Resourc
 	for _, reserve := range sa.reservations {
 		ask := sa.requests[reserve.askKey]
 		// sanity check and cleanup if needed
-		if ask == nil || ask.pendingRepeatAsk == 0 {
+		if ask == nil || ask.getPendingAskRepeat() == 0 {
 			var unreserveAsk *schedulingAllocationAsk
 			// if the ask was not found we need to construct one to unreserve
 			if ask == nil {

--- a/pkg/scheduler/scheduling_queue.go
+++ b/pkg/scheduler/scheduling_queue.go
@@ -193,11 +193,12 @@ func (sq *SchedulingQueue) removeSchedulingApplication(app *SchedulingApplicatio
 }
 
 // Get a copy of the child queues
-// Lock free call: this is used by the partition manager to find all queues to clean
-// however we can not guarantee that there is no new child added while we clean up since
-// there is no overall lock on the scheduler. We'll need to test just before to make sure
-// the parent is empty
+// This is used by the partition manager to find all queues to clean however we can not
+// guarantee that there is no new child added while we clean up since there is no overall
+// lock on the scheduler. We'll need to test just before to make sure the parent is empty
 func (sq *SchedulingQueue) GetCopyOfChildren() map[string]*SchedulingQueue {
+	sq.RLock()
+	defer sq.RUnlock()
 	children := make(map[string]*SchedulingQueue)
 	for k, v := range sq.childrenQueues {
 		children[k] = v

--- a/pkg/scheduler/scheduling_queue_test.go
+++ b/pkg/scheduler/scheduling_queue_test.go
@@ -872,3 +872,24 @@ func TestGetApp(t *testing.T) {
 		t.Errorf("un registered app found using appID which should not happen: %v", unknown)
 	}
 }
+
+func TestIsEmpty(t *testing.T) {
+	// create the root
+	root, err := createRootQueue(nil)
+	if err != nil {
+		t.Fatalf("failed to create basic root queue: %v", err)
+	}
+	assert.Equal(t, root.isEmpty(), true, "new root queue should have been empty")
+	var leaf *SchedulingQueue
+	leaf, err = createManagedQueue(root, "leaf", false, nil)
+	if err != nil {
+		t.Fatalf("failed to create leaf queue: %v", err)
+	}
+	assert.Equal(t, root.isEmpty(), false, "root queue with child leaf should not have been empty")
+	assert.Equal(t, leaf.isEmpty(), true, "new leaf should have been empty")
+
+	// add app and check proper returns
+	app := newSchedulingApplication(&cache.ApplicationInfo{ApplicationID: "app-1"})
+	leaf.addSchedulingApplication(app)
+	assert.Equal(t, leaf.isEmpty(), false, "queue with registered app should not be empty")
+}

--- a/pkg/scheduler/sorters.go
+++ b/pkg/scheduler/sorters.go
@@ -42,8 +42,8 @@ func sortQueue(queues []*SchedulingQueue, sortType SortType) {
 		sort.SliceStable(queues, func(i, j int) bool {
 			l := queues[i]
 			r := queues[j]
-			comp := resources.CompUsageRatioSeparately(l.getAssumeAllocated(), l.QueueInfo.GuaranteedResource,
-				r.getAssumeAllocated(), r.QueueInfo.GuaranteedResource)
+			comp := resources.CompUsageRatioSeparately(l.getAssumeAllocated(), l.QueueInfo.GetGuaranteedResource(),
+				r.getAssumeAllocated(), r.QueueInfo.GetGuaranteedResource())
 			return comp < 0
 		})
 	}

--- a/pkg/scheduler/sorters_test.go
+++ b/pkg/scheduler/sorters_test.go
@@ -38,16 +38,16 @@ func TestSortQueues(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create basic root queue: %v", err)
 	}
-	root.QueueInfo.GuaranteedResource = resources.NewResourceFromMap(
-		map[string]resources.Quantity{"memory": 1000, "vcore": 1000})
+	cache.SetGuaranteedResource(root.QueueInfo,
+		resources.NewResourceFromMap(map[string]resources.Quantity{"memory": 1000, "vcore": 1000}))
 
 	var q0, q1, q2 *SchedulingQueue
 	q0, err = createManagedQueue(root, "q0", false, nil)
 	if err != nil {
 		t.Fatalf("failed to create leaf queue: %v", err)
 	}
-	q0.QueueInfo.GuaranteedResource = resources.NewResourceFromMap(
-		map[string]resources.Quantity{"memory": 500, "vcore": 500})
+	cache.SetGuaranteedResource(q0.QueueInfo,
+		resources.NewResourceFromMap(map[string]resources.Quantity{"memory": 500, "vcore": 500}))
 	q0.allocating = resources.NewResourceFromMap(map[string]resources.Quantity{
 		"memory": resources.Quantity(300),
 		"vcore":  resources.Quantity(300)})
@@ -56,8 +56,8 @@ func TestSortQueues(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create leaf queue: %v", err)
 	}
-	q1.QueueInfo.GuaranteedResource = resources.NewResourceFromMap(
-		map[string]resources.Quantity{"memory": 300, "vcore": 300})
+	cache.SetGuaranteedResource(q1.QueueInfo,
+		resources.NewResourceFromMap(map[string]resources.Quantity{"memory": 300, "vcore": 300}))
 	q1.allocating = resources.NewResourceFromMap(map[string]resources.Quantity{
 		"memory": resources.Quantity(200),
 		"vcore":  resources.Quantity(200)})
@@ -66,8 +66,8 @@ func TestSortQueues(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create leaf queue: %v", err)
 	}
-	q2.QueueInfo.GuaranteedResource = resources.NewResourceFromMap(
-		map[string]resources.Quantity{"memory": 200, "vcore": 200})
+	cache.SetGuaranteedResource(q2.QueueInfo,
+		resources.NewResourceFromMap(map[string]resources.Quantity{"memory": 200, "vcore": 200}))
 	q2.allocating = resources.NewResourceFromMap(map[string]resources.Quantity{
 		"memory": resources.Quantity(100),
 		"vcore":  resources.Quantity(100)})
@@ -100,16 +100,16 @@ func TestNoQueueLimits(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create basic root queue: %v", err)
 	}
-	root.QueueInfo.GuaranteedResource = resources.NewResourceFromMap(
-		map[string]resources.Quantity{"memory": 0, "vcore": 0})
+	cache.SetGuaranteedResource(root.QueueInfo,
+		resources.NewResourceFromMap(map[string]resources.Quantity{"memory": 0, "vcore": 0}))
 
 	var q0, q1, q2 *SchedulingQueue
 	q0, err = createManagedQueue(root, "q0", false, nil)
 	if err != nil {
 		t.Fatalf("failed to create leaf queue: %v", err)
 	}
-	q0.QueueInfo.GuaranteedResource = resources.NewResourceFromMap(
-		map[string]resources.Quantity{"memory": 0, "vcore": 0})
+	cache.SetGuaranteedResource(q0.QueueInfo,
+		resources.NewResourceFromMap(map[string]resources.Quantity{"memory": 0, "vcore": 0}))
 	q0.allocating = resources.NewResourceFromMap(map[string]resources.Quantity{
 		"memory": resources.Quantity(300),
 		"vcore":  resources.Quantity(300)})
@@ -118,8 +118,8 @@ func TestNoQueueLimits(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create leaf queue: %v", err)
 	}
-	q1.QueueInfo.GuaranteedResource = resources.NewResourceFromMap(
-		map[string]resources.Quantity{"memory": 0, "vcore": 0})
+	cache.SetGuaranteedResource(q1.QueueInfo,
+		resources.NewResourceFromMap(map[string]resources.Quantity{"memory": 0, "vcore": 0}))
 	q1.allocating = resources.NewResourceFromMap(map[string]resources.Quantity{
 		"memory": resources.Quantity(200),
 		"vcore":  resources.Quantity(200)})
@@ -128,8 +128,8 @@ func TestNoQueueLimits(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create leaf queue: %v", err)
 	}
-	q2.QueueInfo.GuaranteedResource = resources.NewResourceFromMap(map[string]resources.Quantity{
-		"memory": 0, "vcore": 0})
+	cache.SetGuaranteedResource(q2.QueueInfo,
+		resources.NewResourceFromMap(map[string]resources.Quantity{"memory": 0, "vcore": 0}))
 	q2.allocating = resources.NewResourceFromMap(map[string]resources.Quantity{
 		"memory": resources.Quantity(100),
 		"vcore":  resources.Quantity(100)})
@@ -152,14 +152,14 @@ func TestQueueGuaranteedResourceNotSet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create basic root queue: %v", err)
 	}
-	root.QueueInfo.GuaranteedResource = nil
+	cache.SetGuaranteedResource(root.QueueInfo, nil)
 
 	var q0, q1, q2 *SchedulingQueue
 	q0, err = createManagedQueue(root, "q0", false, nil)
 	if err != nil {
 		t.Fatalf("failed to create leaf queue: %v", err)
 	}
-	q0.QueueInfo.GuaranteedResource = nil
+	cache.SetGuaranteedResource(q0.QueueInfo, nil)
 	q0.allocating = resources.NewResourceFromMap(map[string]resources.Quantity{
 		"memory": resources.Quantity(300),
 		"vcore":  resources.Quantity(300)})
@@ -168,7 +168,7 @@ func TestQueueGuaranteedResourceNotSet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create leaf queue: %v", err)
 	}
-	q1.QueueInfo.GuaranteedResource = nil
+	cache.SetGuaranteedResource(q1.QueueInfo, nil)
 	q1.allocating = resources.NewResourceFromMap(map[string]resources.Quantity{
 		"memory": resources.Quantity(200),
 		"vcore":  resources.Quantity(200)})
@@ -178,7 +178,7 @@ func TestQueueGuaranteedResourceNotSet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create leaf queue: %v", err)
 	}
-	q2.QueueInfo.GuaranteedResource = nil
+	cache.SetGuaranteedResource(q2.QueueInfo, nil)
 
 	queues := []*SchedulingQueue{q0, q1, q2}
 	sortQueue(queues, FairSortPolicy)

--- a/pkg/scheduler/tests/scheduler_recovery_test.go
+++ b/pkg/scheduler/tests/scheduler_recovery_test.go
@@ -317,8 +317,8 @@ partitions:
 	// verify queues
 	//  - verify root queue
 	t.Log("verifying root queue")
-	assert.Equal(t, partition.Root.GuaranteedResource.Resources[resources.MEMORY], resources.Quantity(100))
-	assert.Equal(t, partition.Root.GuaranteedResource.Resources[resources.VCORE], resources.Quantity(10))
+	assert.Equal(t, partition.Root.GetGuaranteedResource().Resources[resources.MEMORY], resources.Quantity(100))
+	assert.Equal(t, partition.Root.GetGuaranteedResource().Resources[resources.VCORE], resources.Quantity(10))
 	assert.Equal(t, partition.Root.GetAllocatedResource().Resources[resources.MEMORY], resources.Quantity(120))
 	assert.Equal(t, partition.Root.GetAllocatedResource().Resources[resources.VCORE], resources.Quantity(12))
 	//  - verify root.a queue

--- a/pkg/scheduler/tests/scheduler_smoke_test.go
+++ b/pkg/scheduler/tests/scheduler_smoke_test.go
@@ -124,7 +124,7 @@ partitions:
 	// Check scheduling queue root.base
 	schedulerQueue = ms.getSchedulingQueue("root.base")
 	assert.Assert(t, 1000 == schedulerQueue.QueueInfo.GetMaxResource().Resources[resources.MEMORY])
-	assert.Assert(t, 250 == schedulerQueue.QueueInfo.GuaranteedResource.Resources[resources.VCORE])
+	assert.Assert(t, 250 == schedulerQueue.QueueInfo.GetGuaranteedResource().Resources[resources.VCORE])
 
 	// check the removed queue state
 	schedulerQueue = ms.getSchedulingQueue("root.tobedeleted")


### PR DESCRIPTION
Deadlock in the scheduler when restoring a node with allocations
Data race fixes around guaranteed resource of a queue and ask repeat