### PR TITLE
[YUNIKORN-14] Add rest API to retrieve app/container history info

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.9.1
 	github.com/satori/go.uuid v1.2.0
-	github.com/stretchr/testify v1.5.1
+	github.com/stretchr/testify v1.5.1 //indirect
 	go.uber.org/atomic v1.5.1 // indirect
 	go.uber.org/multierr v1.4.0 // indirect
 	go.uber.org/zap v1.13.0

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/apache/incubator-yunikorn-scheduler-interface v0.0.0-20200327234544-149aaa3d8e48
-	github.com/golang/protobuf v1.3.5
+	github.com/golang/protobuf v1.3.5 // indirect
 	github.com/gorilla/mux v1.7.3
 	github.com/kr/text v0.2.0 // indirect
 	github.com/looplab/fsm v0.1.0

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.9.1
 	github.com/satori/go.uuid v1.2.0
-	github.com/stretchr/testify v1.5.1 // indirect
+	github.com/stretchr/testify v1.5.1
 	go.uber.org/atomic v1.5.1 // indirect
 	go.uber.org/multierr v1.4.0 // indirect
 	go.uber.org/zap v1.13.0

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/apache/incubator-yunikorn-scheduler-interface v0.0.0-20200327234544-149aaa3d8e48
-	github.com/golang/protobuf v1.3.5 // indirect
+	github.com/golang/protobuf v1.3.5
 	github.com/gorilla/mux v1.7.3
 	github.com/kr/text v0.2.0 // indirect
 	github.com/looplab/fsm v0.1.0
@@ -13,6 +13,7 @@ require (
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.4.0
+	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.9.1
 	github.com/satori/go.uuid v1.2.0
 	github.com/stretchr/testify v1.5.1 // indirect

--- a/pkg/entrypoint/entrypoint.go
+++ b/pkg/entrypoint/entrypoint.go
@@ -80,8 +80,9 @@ func startAllServicesWithParameters(opts StartupOptions) *ServiceContext {
 		Scheduler: scheduler,
 	}
 
-	imHistory := history.NewInternalMetricsHistory(opts.metricsHistorySize)
+	var imHistory *history.InternalMetricsHistory
 	if opts.metricsHistorySize != 0 {
+		imHistory = history.NewInternalMetricsHistory(opts.metricsHistorySize)
 		metricsCollector := metrics.NewInternalMetricsCollector(imHistory)
 		metricsCollector.StartService()
 	}

--- a/pkg/metrics/history/internal_metrics.go
+++ b/pkg/metrics/history/internal_metrics.go
@@ -1,0 +1,74 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package history
+
+import (
+	"sync"
+	"time"
+)
+
+// This class collects basic information about the cluster
+// for the web UI's front page.
+// For more detailed metrics collection use Prometheus.
+type InternalMetricsHistory struct {
+	records []*MetricsRecord
+	limit   int
+	mutex   sync.Mutex
+}
+
+type MetricsRecord struct {
+	Timestamp         time.Time
+	TotalApplications int
+	TotalContainers   int
+}
+
+func NewInternalMetricsHistory(limit int) *InternalMetricsHistory {
+	return &InternalMetricsHistory{
+		records: make([]*MetricsRecord, 0),
+		limit:   limit,
+	}
+}
+
+func (h *InternalMetricsHistory) Store(totalApplications, totalContainers int) {
+	h.mutex.Lock()
+	defer h.mutex.Unlock()
+
+	h.records = append(h.records,
+		&MetricsRecord{
+			time.Now(),
+			totalApplications,
+			totalContainers,
+		})
+	if len(h.records) > h.limit {
+		// remove oldest entry
+		h.records = h.records[1:]
+	}
+}
+
+func (h *InternalMetricsHistory) GetRecords() []*MetricsRecord {
+	h.mutex.Lock()
+	defer h.mutex.Unlock()
+	return h.records
+}
+
+func (h *InternalMetricsHistory) GetLimit() int {
+	h.mutex.Lock()
+	defer h.mutex.Unlock()
+	return h.limit
+}

--- a/pkg/metrics/history/internal_metrics.go
+++ b/pkg/metrics/history/internal_metrics.go
@@ -58,7 +58,6 @@ func (h *InternalMetricsHistory) Store(totalApplications, totalContainers int) {
 		totalApplications,
 		totalContainers,
 	}
-
 	h.pointer++
 	if h.pointer == h.limit {
 		h.pointer = 0
@@ -74,7 +73,6 @@ func (h *InternalMetricsHistory) GetRecords() []*metricsRecord {
 	returnRecords := make([]*metricsRecord, h.limit-h.pointer)
 	copy(returnRecords, h.records[h.pointer:])
 	returnRecords = append(returnRecords, h.records[:h.pointer]...)
-
 	return returnRecords
 }
 

--- a/pkg/metrics/history/internal_metrics_test.go
+++ b/pkg/metrics/history/internal_metrics_test.go
@@ -24,6 +24,16 @@ import (
 	"gotest.tools/assert"
 )
 
+func countNils(records []*metricsRecord) int {
+	count := 0
+	for _, record := range records {
+		if record == nil {
+			count++
+		}
+	}
+	return count
+}
+
 func TestHistoricalClusterInfo(t *testing.T) {
 	limit := 2
 	hpInfo := NewInternalMetricsHistory(limit)
@@ -31,13 +41,19 @@ func TestHistoricalClusterInfo(t *testing.T) {
 	assert.Equal(t, limit, hpInfo.GetLimit(), "Limit should have been set to 2!")
 
 	hpInfo.Store(2, 3)
-	assert.Equal(t, 1, len(hpInfo.GetRecords()), "Expected to have 1 record")
+	records := hpInfo.GetRecords()
+	assert.Equal(t, 2, len(records), "Expected to have 1 non nil record.")
+	assert.Equal(t, 1, countNils(records), "Expected to have 1 non nil record.")
 
 	hpInfo.Store(3, 4)
-	assert.Equal(t, 2, len(hpInfo.GetRecords()), "Expected to have 2 records")
+	records = hpInfo.GetRecords()
+	assert.Equal(t, 2, len(records), "Expected to have 2 records")
+	assert.Equal(t, 0, countNils(records), "Expected to have 0 non nil record.")
 
 	hpInfo.Store(5, 6)
-	assert.Equal(t, 2, len(hpInfo.GetRecords()), "Expected to have 2 records")
+	records = hpInfo.GetRecords()
+	assert.Equal(t, 2, len(records), "Expected to have 2 records")
+	assert.Equal(t, 0, countNils(records), "Expected to have 0 non nil record.")
 
 	for i, record := range hpInfo.GetRecords() {
 		switch i {

--- a/pkg/metrics/history/internal_metrics_test.go
+++ b/pkg/metrics/history/internal_metrics_test.go
@@ -31,16 +31,13 @@ func TestHistoricalClusterInfo(t *testing.T) {
 	assert.Equal(t, limit, hpInfo.GetLimit(), "Limit should have been set to 2!")
 
 	hpInfo.Store(2, 3)
-	assert.Equal(t, 1, len(hpInfo.GetRecords()),
-		"Expected to have 1 record")
+	assert.Equal(t, 1, len(hpInfo.GetRecords()), "Expected to have 1 record")
 
 	hpInfo.Store(3, 4)
-	assert.Equal(t, 2, len(hpInfo.GetRecords()),
-		"Expected to have 2 records")
+	assert.Equal(t, 2, len(hpInfo.GetRecords()), "Expected to have 2 records")
 
 	hpInfo.Store(5, 6)
-	assert.Equal(t, 2, len(hpInfo.GetRecords()),
-		"Expected to have 2 records")
+	assert.Equal(t, 2, len(hpInfo.GetRecords()), "Expected to have 2 records")
 
 	for i, record := range hpInfo.GetRecords() {
 		switch i {

--- a/pkg/metrics/history/internal_metrics_test.go
+++ b/pkg/metrics/history/internal_metrics_test.go
@@ -1,0 +1,55 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package history
+
+import (
+	"testing"
+
+	"gotest.tools/assert"
+)
+
+func TestHistoricalClusterInfo(t *testing.T) {
+	limit := 2
+	hpInfo := NewInternalMetricsHistory(limit)
+
+	assert.Equal(t, limit, hpInfo.GetLimit(), "Limit should have been set to 2!")
+
+	hpInfo.Store(2, 3)
+	assert.Equal(t, 1, len(hpInfo.GetRecords()),
+		"Expected to have 1 record")
+
+	hpInfo.Store(3, 4)
+	assert.Equal(t, 2, len(hpInfo.GetRecords()),
+		"Expected to have 2 records")
+
+	hpInfo.Store(5, 6)
+	assert.Equal(t, 2, len(hpInfo.GetRecords()),
+		"Expected to have 2 records")
+
+	for i, record := range hpInfo.GetRecords() {
+		switch i {
+		case 0:
+			assert.Equal(t, 3, record.TotalApplications)
+			assert.Equal(t, 4, record.TotalContainers)
+		case 1:
+			assert.Equal(t, 5, record.TotalApplications)
+			assert.Equal(t, 6, record.TotalContainers)
+		}
+	}
+}

--- a/pkg/metrics/init.go
+++ b/pkg/metrics/init.go
@@ -21,6 +21,8 @@ package metrics
 import (
 	"sync"
 	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 const (
@@ -54,6 +56,7 @@ type CoreSchedulerMetrics interface {
 	// Metrics Ops related to ScheduledAllocationSuccesses
 	IncAllocatedContainer()
 	AddAllocatedContainers(value int)
+	getAllocatedContainers() *prometheus.Counter
 
 	// Metrics Ops related to ScheduledAllocationFailures
 	IncRejectedContainer()
@@ -81,6 +84,7 @@ type CoreSchedulerMetrics interface {
 	DecTotalApplicationsRunning()
 	SubTotalApplicationsRunning(value int)
 	SetTotalApplicationsRunning(value int)
+	getTotalApplicationsRunning() *prometheus.Gauge
 
 	// Metrics Ops related to TotalApplicationsCompleted
 	IncTotalApplicationsCompleted()

--- a/pkg/metrics/init.go
+++ b/pkg/metrics/init.go
@@ -21,8 +21,6 @@ package metrics
 import (
 	"sync"
 	"time"
-
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 const (
@@ -56,7 +54,7 @@ type CoreSchedulerMetrics interface {
 	// Metrics Ops related to ScheduledAllocationSuccesses
 	IncAllocatedContainer()
 	AddAllocatedContainers(value int)
-	getAllocatedContainers() *prometheus.Counter
+	getAllocatedContainers() (int, error)
 
 	// Metrics Ops related to ScheduledAllocationFailures
 	IncRejectedContainer()
@@ -84,7 +82,7 @@ type CoreSchedulerMetrics interface {
 	DecTotalApplicationsRunning()
 	SubTotalApplicationsRunning(value int)
 	SetTotalApplicationsRunning(value int)
-	getTotalApplicationsRunning() *prometheus.Gauge
+	getTotalApplicationsRunning() (int, error)
 
 	// Metrics Ops related to TotalApplicationsCompleted
 	IncTotalApplicationsCompleted()

--- a/pkg/metrics/metrics_collector.go
+++ b/pkg/metrics/metrics_collector.go
@@ -29,6 +29,8 @@ import (
 
 var tickerDefault = 1 * time.Minute
 
+// collecting metrics for YuniKorn-internal usage
+// will fill missing values with -1, in case of failures
 type internalMetricsCollector struct {
 	ticker         *time.Ticker
 	stopped        chan bool
@@ -58,12 +60,12 @@ func (u *internalMetricsCollector) StartService() {
 				totalAppsRunning, err := m.scheduler.getTotalApplicationsRunning()
 				if err != nil {
 					log.Logger().Warn("Could not encode totalApplications metric.", zap.Error(err))
-					continue
+					totalAppsRunning = -1
 				}
 				totalContainersRunning, err := m.scheduler.getAllocatedContainers()
 				if err != nil {
 					log.Logger().Warn("Could not encode totalContainers metric.", zap.Error(err))
-					continue
+					totalContainersRunning = -1
 				}
 				u.metricsHistory.Store(totalAppsRunning, totalContainersRunning)
 			}

--- a/pkg/metrics/metrics_collector.go
+++ b/pkg/metrics/metrics_collector.go
@@ -29,24 +29,24 @@ import (
 
 var tickerDefault = 1 * time.Minute
 
-type InternalMetricsCollector struct {
+type internalMetricsCollector struct {
 	ticker         *time.Ticker
 	stopped        chan bool
 	metricsHistory *history.InternalMetricsHistory
 }
 
-func NewInternalMetricsCollector(hcInfo *history.InternalMetricsHistory) *InternalMetricsCollector {
+func NewInternalMetricsCollector(hcInfo *history.InternalMetricsHistory) *internalMetricsCollector {
 	finished := make(chan bool)
 	ticker := time.NewTicker(tickerDefault)
 
-	return &InternalMetricsCollector{
+	return &internalMetricsCollector{
 		ticker,
 		finished,
 		hcInfo,
 	}
 }
 
-func (u *InternalMetricsCollector) StartService() {
+func (u *internalMetricsCollector) StartService() {
 	go func() {
 		for {
 			select {
@@ -57,12 +57,12 @@ func (u *InternalMetricsCollector) StartService() {
 
 				totalAppsRunning, err := m.scheduler.getTotalApplicationsRunning()
 				if err != nil {
-					log.Logger().Warn("Could not encode metric.", zap.Error(err))
+					log.Logger().Warn("Could not encode totalApplications metric.", zap.Error(err))
 					continue
 				}
 				totalContainersRunning, err := m.scheduler.getAllocatedContainers()
 				if err != nil {
-					log.Logger().Warn("Could not encode metric.", zap.Error(err))
+					log.Logger().Warn("Could not encode totalContainers metric.", zap.Error(err))
 					continue
 				}
 				u.metricsHistory.Store(totalAppsRunning, totalContainersRunning)
@@ -71,7 +71,7 @@ func (u *InternalMetricsCollector) StartService() {
 	}()
 }
 
-func (u *InternalMetricsCollector) Stop() {
+func (u *internalMetricsCollector) Stop() {
 	u.stopped <- true
 }
 

--- a/pkg/metrics/metrics_collector.go
+++ b/pkg/metrics/metrics_collector.go
@@ -1,0 +1,89 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package metrics
+
+import (
+	"time"
+
+	dto "github.com/prometheus/client_model/go"
+	"go.uber.org/zap"
+
+	"github.com/apache/incubator-yunikorn-core/pkg/log"
+	"github.com/apache/incubator-yunikorn-core/pkg/metrics/history"
+)
+
+var tickerDefault = 1 * time.Minute
+
+type InternalMetricsCollector struct {
+	ticker         *time.Ticker
+	stopped        chan bool
+	metricsHistory *history.InternalMetricsHistory
+}
+
+func NewInternalMetricsCollector(hcInfo *history.InternalMetricsHistory) *InternalMetricsCollector {
+	finished := make(chan bool)
+	ticker := time.NewTicker(tickerDefault)
+
+	return &InternalMetricsCollector{
+		ticker,
+		finished,
+		hcInfo,
+	}
+}
+
+func (u *InternalMetricsCollector) StartService() {
+	go func() {
+		for {
+			select {
+			case <-u.stopped:
+				return
+			case <-u.ticker.C:
+				log.Logger().Debug("Adding current status to historical partition data")
+
+				totalAppsRunningMetric := &dto.Metric{}
+				totalAppsRunningMetricGauge := m.scheduler.getTotalApplicationsRunning()
+				err := (*totalAppsRunningMetricGauge).Write(totalAppsRunningMetric)
+				if err != nil {
+					log.Logger().Warn("Could not encode metric.", zap.Error(err))
+					continue
+				}
+
+				totalContainersRunningMetric := &dto.Metric{}
+				totalContainersRunningMetricCounter := m.scheduler.getAllocatedContainers()
+				err = (*totalContainersRunningMetricCounter).Write(totalContainersRunningMetric)
+				if err != nil {
+					log.Logger().Warn("Could not encode metric.", zap.Error(err))
+					continue
+				}
+
+				u.metricsHistory.Store(
+					int(*totalAppsRunningMetric.Gauge.Value),
+					int(*totalContainersRunningMetric.Counter.Value))
+			}
+		}
+	}()
+}
+
+func (u *InternalMetricsCollector) Stop() {
+	u.stopped <- true
+}
+
+func setInternalMetricsCollectorTickerForTest(newDefault time.Duration) {
+	tickerDefault = newDefault
+}

--- a/pkg/metrics/metrics_collector_test.go
+++ b/pkg/metrics/metrics_collector_test.go
@@ -23,7 +23,7 @@ import (
 	"time"
 
 	"github.com/apache/incubator-yunikorn-core/pkg/metrics/history"
-	"github.com/stretchr/testify/assert"
+	"gotest.tools/assert"
 )
 
 func TestHistoricalPartitionInfoUpdater(t *testing.T) {
@@ -47,14 +47,17 @@ func TestHistoricalPartitionInfoUpdater(t *testing.T) {
 	metricsCollector.Stop()
 
 	records := metricsHistory.GetRecords()
-	assert.Equal(t, 3, len(records), "Expected exactly 2 history records")
+	assert.Equal(t, 3, len(records), "Expected exactly 3 history records")
 	for i, record := range records {
-		if i == 0 {
-			assert.Nil(t, nil, "The 1st item should be nil!")
-		} else if i == 1 {
+		switch i {
+		case 0:
+			if record != nil {
+				t.Fatal("The 1st item should be nil!")
+			}
+		case 1:
 			assert.Equal(t, 2, record.TotalApplications, "Expected exactly 2 applications at 10 msec")
 			assert.Equal(t, 4, record.TotalContainers, "Expected exactly 4 allocations at 10 msec")
-		} else if i == 2 {
+		case 2:
 			assert.Equal(t, 3, record.TotalApplications, "Expected exactly 3 applications at 20 msec")
 			assert.Equal(t, 6, record.TotalContainers, "Expected exactly 4 allocations at 20 msec")
 		}

--- a/pkg/metrics/metrics_collector_test.go
+++ b/pkg/metrics/metrics_collector_test.go
@@ -22,9 +22,8 @@ import (
 	"testing"
 	"time"
 
-	"gotest.tools/assert"
-
 	"github.com/apache/incubator-yunikorn-core/pkg/metrics/history"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestHistoricalPartitionInfoUpdater(t *testing.T) {
@@ -48,12 +47,14 @@ func TestHistoricalPartitionInfoUpdater(t *testing.T) {
 	metricsCollector.Stop()
 
 	records := metricsHistory.GetRecords()
-	assert.Equal(t, 2, len(records), "Expected exactly 2 history records")
+	assert.Equal(t, 3, len(records), "Expected exactly 2 history records")
 	for i, record := range records {
 		if i == 0 {
+			assert.Nil(t, nil, "The 1st item should be nil!")
+		} else if i == 1 {
 			assert.Equal(t, 2, record.TotalApplications, "Expected exactly 2 applications at 10 msec")
 			assert.Equal(t, 4, record.TotalContainers, "Expected exactly 4 allocations at 10 msec")
-		} else if i == 1 {
+		} else if i == 2 {
 			assert.Equal(t, 3, record.TotalApplications, "Expected exactly 3 applications at 20 msec")
 			assert.Equal(t, 6, record.TotalContainers, "Expected exactly 4 allocations at 20 msec")
 		}

--- a/pkg/metrics/metrics_collector_test.go
+++ b/pkg/metrics/metrics_collector_test.go
@@ -1,0 +1,65 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	"gotest.tools/assert"
+
+	"github.com/apache/incubator-yunikorn-core/pkg/metrics/history"
+)
+
+func TestHistoricalPartitionInfoUpdater(t *testing.T) {
+	metricsHistory := history.NewInternalMetricsHistory(3)
+	setInternalMetricsCollectorTickerForTest(500 * time.Millisecond)
+	metricsCollector := NewInternalMetricsCollector(metricsHistory)
+	metricsCollector.StartService()
+
+	go func() {
+		metrics := GetSchedulerMetrics()
+		i := 0
+		for i < 3 {
+			metrics.IncTotalApplicationsRunning()
+			metrics.AddAllocatedContainers(2)
+			i += 1
+			time.Sleep(400 * time.Millisecond)
+		}
+	}()
+
+	time.Sleep(1100 * time.Millisecond)
+	metricsCollector.Stop()
+
+	records := metricsHistory.GetRecords()
+	assert.Equal(t, 2, len(records), "Expected exactly 2 history records")
+	for i, record := range records {
+		if i == 0 {
+			assert.Equal(t, 2, record.TotalApplications,
+				"Expected exactly 2 applications at 0.5 sec")
+			assert.Equal(t, 4, record.TotalContainers,
+				"Expected exactly 4 allocations at 0.5 sec")
+		} else if i == 1 {
+			assert.Equal(t, 3, record.TotalApplications,
+				"Expected exactly 3 applications at 1 sec")
+			assert.Equal(t, 6, record.TotalContainers,
+				"Expected exactly 4 allocations at 1 sec")
+		}
+	}
+}

--- a/pkg/metrics/metrics_collector_test.go
+++ b/pkg/metrics/metrics_collector_test.go
@@ -29,7 +29,7 @@ import (
 
 func TestHistoricalPartitionInfoUpdater(t *testing.T) {
 	metricsHistory := history.NewInternalMetricsHistory(3)
-	setInternalMetricsCollectorTickerForTest(500 * time.Millisecond)
+	setInternalMetricsCollectorTicker(5 * time.Millisecond)
 	metricsCollector := NewInternalMetricsCollector(metricsHistory)
 	metricsCollector.StartService()
 
@@ -40,26 +40,22 @@ func TestHistoricalPartitionInfoUpdater(t *testing.T) {
 			metrics.IncTotalApplicationsRunning()
 			metrics.AddAllocatedContainers(2)
 			i += 1
-			time.Sleep(400 * time.Millisecond)
+			time.Sleep(4 * time.Millisecond)
 		}
 	}()
 
-	time.Sleep(1100 * time.Millisecond)
+	time.Sleep(11 * time.Millisecond)
 	metricsCollector.Stop()
 
 	records := metricsHistory.GetRecords()
 	assert.Equal(t, 2, len(records), "Expected exactly 2 history records")
 	for i, record := range records {
 		if i == 0 {
-			assert.Equal(t, 2, record.TotalApplications,
-				"Expected exactly 2 applications at 0.5 sec")
-			assert.Equal(t, 4, record.TotalContainers,
-				"Expected exactly 4 allocations at 0.5 sec")
+			assert.Equal(t, 2, record.TotalApplications, "Expected exactly 2 applications at 10 msec")
+			assert.Equal(t, 4, record.TotalContainers, "Expected exactly 4 allocations at 10 msec")
 		} else if i == 1 {
-			assert.Equal(t, 3, record.TotalApplications,
-				"Expected exactly 3 applications at 1 sec")
-			assert.Equal(t, 6, record.TotalContainers,
-				"Expected exactly 4 allocations at 1 sec")
+			assert.Equal(t, 3, record.TotalApplications, "Expected exactly 3 applications at 20 msec")
+			assert.Equal(t, 6, record.TotalContainers, "Expected exactly 4 allocations at 20 msec")
 		}
 	}
 }

--- a/pkg/metrics/scheduler.go
+++ b/pkg/metrics/scheduler.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"go.uber.org/zap"
 
 	"github.com/apache/incubator-yunikorn-core/pkg/log"
@@ -200,8 +201,10 @@ func (m *SchedulerMetrics) AddAllocatedContainers(value int) {
 	m.allocatedContainers.Add(float64(value))
 }
 
-func (m *SchedulerMetrics) getAllocatedContainers() *prometheus.Counter {
-	return &m.allocatedContainers
+func (m *SchedulerMetrics) getAllocatedContainers() (int, error) {
+	metric := &dto.Metric{}
+	err := m.allocatedContainers.Write(metric)
+	return int(*metric.Counter.Value), err
 }
 
 func (m *SchedulerMetrics) IncReleasedContainer() {
@@ -269,8 +272,10 @@ func (m *SchedulerMetrics) SetTotalApplicationsRunning(value int) {
 	m.totalApplicationsRunning.Set(float64(value))
 }
 
-func (m *SchedulerMetrics) getTotalApplicationsRunning() *prometheus.Gauge {
-	return &m.totalApplicationsRunning
+func (m *SchedulerMetrics) getTotalApplicationsRunning() (int, error) {
+	metric := &dto.Metric{}
+	err := m.totalApplicationsRunning.Write(metric)
+	return int(*metric.Gauge.Value), err
 }
 
 // Metrics Ops related to totalApplicationsCompleted

--- a/pkg/metrics/scheduler.go
+++ b/pkg/metrics/scheduler.go
@@ -201,10 +201,12 @@ func (m *SchedulerMetrics) AddAllocatedContainers(value int) {
 	m.allocatedContainers.Add(float64(value))
 }
 
-func (m *SchedulerMetrics) getAllocatedContainers() (int, error) {
-	metric := &dto.Metric{}
-	err := m.allocatedContainers.Write(metric)
-	return int(*metric.Counter.Value), err
+func (m *SchedulerMetrics) getAllocatedContainers() (value int, err error) {
+	metricDto := &dto.Metric{}
+	if err = m.allocatedContainers.Write(metricDto); err == nil {
+		value = int(*metricDto.Counter.Value)
+	}
+	return
 }
 
 func (m *SchedulerMetrics) IncReleasedContainer() {

--- a/pkg/metrics/scheduler.go
+++ b/pkg/metrics/scheduler.go
@@ -200,6 +200,10 @@ func (m *SchedulerMetrics) AddAllocatedContainers(value int) {
 	m.allocatedContainers.Add(float64(value))
 }
 
+func (m *SchedulerMetrics) getAllocatedContainers() *prometheus.Counter {
+	return &m.allocatedContainers
+}
+
 func (m *SchedulerMetrics) IncReleasedContainer() {
 	m.releasedContainers.Inc()
 }
@@ -263,6 +267,10 @@ func (m *SchedulerMetrics) SubTotalApplicationsRunning(value int) {
 
 func (m *SchedulerMetrics) SetTotalApplicationsRunning(value int) {
 	m.totalApplicationsRunning.Set(float64(value))
+}
+
+func (m *SchedulerMetrics) getTotalApplicationsRunning() *prometheus.Gauge {
+	return &m.totalApplicationsRunning
 }
 
 // Metrics Ops related to totalApplicationsCompleted

--- a/pkg/metrics/scheduler.go
+++ b/pkg/metrics/scheduler.go
@@ -201,12 +201,13 @@ func (m *SchedulerMetrics) AddAllocatedContainers(value int) {
 	m.allocatedContainers.Add(float64(value))
 }
 
-func (m *SchedulerMetrics) getAllocatedContainers() (value int, err error) {
+func (m *SchedulerMetrics) getAllocatedContainers() (int, error) {
 	metricDto := &dto.Metric{}
-	if err = m.allocatedContainers.Write(metricDto); err == nil {
-		value = int(*metricDto.Counter.Value)
+	if err := m.allocatedContainers.Write(metricDto); err == nil {
+		return int(*metricDto.Counter.Value), nil
+	} else {
+		return -1, err
 	}
-	return
 }
 
 func (m *SchedulerMetrics) IncReleasedContainer() {
@@ -275,9 +276,12 @@ func (m *SchedulerMetrics) SetTotalApplicationsRunning(value int) {
 }
 
 func (m *SchedulerMetrics) getTotalApplicationsRunning() (int, error) {
-	metric := &dto.Metric{}
-	err := m.totalApplicationsRunning.Write(metric)
-	return int(*metric.Gauge.Value), err
+	metricDto := &dto.Metric{}
+	if err := m.totalApplicationsRunning.Write(metricDto); err == nil {
+		return int(*metricDto.Gauge.Value), nil
+	} else {
+		return -1, err
+	}
 }
 
 // Metrics Ops related to totalApplicationsCompleted

--- a/pkg/webservice/dao/application_history.go
+++ b/pkg/webservice/dao/application_history.go
@@ -1,0 +1,24 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package dao
+
+type ApplicationHistoryDAOInfo struct {
+	Timestamp         int64  `json:"timestamp"`
+	TotalApplications string `json:"totalApplications"`
+}

--- a/pkg/webservice/dao/container_history.go
+++ b/pkg/webservice/dao/container_history.go
@@ -1,0 +1,24 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package dao
+
+type ContainerHistoryDAOInfo struct {
+	Timestamp       int64  `json:"timestamp"`
+	TotalContainers string `json:"totalContainers"`
+}

--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -19,7 +19,6 @@ package webservice
 
 import (
 	"encoding/json"
-	"github.com/apache/incubator-yunikorn-core/pkg/common/configs"
 	"io/ioutil"
 	"net/http"
 	"runtime"
@@ -29,6 +28,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/apache/incubator-yunikorn-core/pkg/cache"
+	"github.com/apache/incubator-yunikorn-core/pkg/common/configs"
 	"github.com/apache/incubator-yunikorn-core/pkg/log"
 	"github.com/apache/incubator-yunikorn-core/pkg/webservice/dao"
 )
@@ -234,5 +234,41 @@ func getNodeJSON(nodeInfo *cache.NodeInfo) *dao.NodeDAOInfo {
 		Available:   strings.Trim(nodeInfo.GetAvailableResource().String(), "map"),
 		Allocations: allocations,
 		Schedulable: nodeInfo.IsSchedulable(),
+	}
+}
+
+func GetApplicationHistory(w http.ResponseWriter, r *http.Request) {
+	writeHeaders(w)
+
+	var result []*dao.ApplicationHistoryDAOInfo
+	records := imHistory.GetRecords()
+	for _, record := range records {
+		element := &dao.ApplicationHistoryDAOInfo{
+			Timestamp:         record.Timestamp.UnixNano(),
+			TotalApplications: strconv.Itoa(record.TotalApplications),
+		}
+		result = append(result, element)
+	}
+
+	if err := json.NewEncoder(w).Encode(result); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func GetContainerHistory(w http.ResponseWriter, r *http.Request) {
+	writeHeaders(w)
+
+	var result []*dao.ContainerHistoryDAOInfo
+	records := imHistory.GetRecords()
+	for _, record := range records {
+		element := &dao.ContainerHistoryDAOInfo{
+			Timestamp:       record.Timestamp.UnixNano(),
+			TotalContainers: strconv.Itoa(record.TotalContainers),
+		}
+		result = append(result, element)
+	}
+
+	if err := json.NewEncoder(w).Encode(result); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 }

--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -244,20 +244,20 @@ func GetApplicationHistory(w http.ResponseWriter, r *http.Request) {
 		var result []*dao.ApplicationHistoryDAOInfo
 		records := imHistory.GetRecords()
 		for _, record := range records {
-			if record != nil {
-				element := &dao.ApplicationHistoryDAOInfo{
-					Timestamp:         record.Timestamp.UnixNano(),
-					TotalApplications: strconv.Itoa(record.TotalApplications),
-				}
-				result = append(result, element)
+			if record == nil {
+				break
 			}
+			element := &dao.ApplicationHistoryDAOInfo{
+				Timestamp:         record.Timestamp.UnixNano(),
+				TotalApplications: strconv.Itoa(record.TotalApplications),
+			}
+			result = append(result, element)
 		}
 		if err := json.NewEncoder(w).Encode(result); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
-	} else {
-		http.Error(w, "Internal metrics collection is not enabled.", http.StatusInternalServerError)
 	}
+	http.Error(w, "Internal metrics collection is not enabled.", http.StatusInternalServerError)
 }
 
 func GetContainerHistory(w http.ResponseWriter, r *http.Request) {
@@ -267,18 +267,18 @@ func GetContainerHistory(w http.ResponseWriter, r *http.Request) {
 		var result []*dao.ContainerHistoryDAOInfo
 		records := imHistory.GetRecords()
 		for _, record := range records {
-			if record != nil {
-				element := &dao.ContainerHistoryDAOInfo{
-					Timestamp:       record.Timestamp.UnixNano(),
-					TotalContainers: strconv.Itoa(record.TotalContainers),
-				}
-				result = append(result, element)
+			if record == nil {
+				break
 			}
+			element := &dao.ContainerHistoryDAOInfo{
+				Timestamp:       record.Timestamp.UnixNano(),
+				TotalContainers: strconv.Itoa(record.TotalContainers),
+			}
+			result = append(result, element)
 		}
 		if err := json.NewEncoder(w).Encode(result); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
-	} else {
-		http.Error(w, "Internal metrics collection is not enabled.", http.StatusInternalServerError)
 	}
+	http.Error(w, "Internal metrics collection is not enabled.", http.StatusInternalServerError)
 }

--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -240,35 +240,45 @@ func getNodeJSON(nodeInfo *cache.NodeInfo) *dao.NodeDAOInfo {
 func GetApplicationHistory(w http.ResponseWriter, r *http.Request) {
 	writeHeaders(w)
 
-	var result []*dao.ApplicationHistoryDAOInfo
-	records := imHistory.GetRecords()
-	for _, record := range records {
-		element := &dao.ApplicationHistoryDAOInfo{
-			Timestamp:         record.Timestamp.UnixNano(),
-			TotalApplications: strconv.Itoa(record.TotalApplications),
+	if imHistory != nil {
+		var result []*dao.ApplicationHistoryDAOInfo
+		records := imHistory.GetRecords()
+		for _, record := range records {
+			if record != nil {
+				element := &dao.ApplicationHistoryDAOInfo{
+					Timestamp:         record.Timestamp.UnixNano(),
+					TotalApplications: strconv.Itoa(record.TotalApplications),
+				}
+				result = append(result, element)
+			}
 		}
-		result = append(result, element)
-	}
-
-	if err := json.NewEncoder(w).Encode(result); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		if err := json.NewEncoder(w).Encode(result); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	} else {
+		http.Error(w, "Internal metrics collection is not enabled.", http.StatusInternalServerError)
 	}
 }
 
 func GetContainerHistory(w http.ResponseWriter, r *http.Request) {
 	writeHeaders(w)
 
-	var result []*dao.ContainerHistoryDAOInfo
-	records := imHistory.GetRecords()
-	for _, record := range records {
-		element := &dao.ContainerHistoryDAOInfo{
-			Timestamp:       record.Timestamp.UnixNano(),
-			TotalContainers: strconv.Itoa(record.TotalContainers),
+	if imHistory != nil {
+		var result []*dao.ContainerHistoryDAOInfo
+		records := imHistory.GetRecords()
+		for _, record := range records {
+			if record != nil {
+				element := &dao.ContainerHistoryDAOInfo{
+					Timestamp:       record.Timestamp.UnixNano(),
+					TotalContainers: strconv.Itoa(record.TotalContainers),
+				}
+				result = append(result, element)
+			}
 		}
-		result = append(result, element)
-	}
-
-	if err := json.NewEncoder(w).Encode(result); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		if err := json.NewEncoder(w).Encode(result); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	} else {
+		http.Error(w, "Internal metrics collection is not enabled.", http.StatusInternalServerError)
 	}
 }

--- a/pkg/webservice/routes.go
+++ b/pkg/webservice/routes.go
@@ -84,6 +84,20 @@ var routes = Routes{
 		ValidateConf,
 	},
 
+	// endpoint to retrieve historical data
+	Route{
+		"Scheduler",
+		"GET",
+		"/ws/v1/history/apps",
+		GetApplicationHistory,
+	},
+	Route{
+		"Scheduler",
+		"GET",
+		"/ws/v1/history/containers",
+		GetContainerHistory,
+	},
+
 	// endpoint to retrieve CPU, Memory profiling data,
 	// this works with pprof tool. By default, pprof endpoints
 	// are only registered to http.DefaultServeMux. Here, we

--- a/pkg/webservice/webservice.go
+++ b/pkg/webservice/webservice.go
@@ -29,9 +29,11 @@ import (
 
 	"github.com/apache/incubator-yunikorn-core/pkg/cache"
 	"github.com/apache/incubator-yunikorn-core/pkg/log"
+	"github.com/apache/incubator-yunikorn-core/pkg/metrics/history"
 )
 
 var gClusterInfo *cache.ClusterInfo
+var imHistory *history.InternalMetricsHistory
 
 type WebService struct {
 	httpServer  *http.Server
@@ -82,9 +84,10 @@ func (m *WebService) StartWebApp() {
 	}()
 }
 
-func NewWebApp(clusterInfo *cache.ClusterInfo) *WebService {
+func NewWebApp(clusterInfo *cache.ClusterInfo, internalMetrics *history.InternalMetricsHistory) *WebService {
 	m := &WebService{}
 	gClusterInfo = clusterInfo
+	imHistory = internalMetrics
 	return m
 }
 


### PR DESCRIPTION
This PR only handles the server (core) part of this issue. The UI related changes will be handled in [YUNIKORN-8](https://issues.apache.org/jira/browse/YUNIKORN-8).

The initial implementation consists of creating a `HistoricalPartitionInfo` object which stores some metrics (currently the number of application and containers). This is updated in 10 minutes by `HistoricalPartitionInfoUpdater`

If there's need the poll time can be configurable, right now it is just hardcoded to 10 minutes, and we will keep 1 day of history (144 items).