### PR TITLE
[YUNIKORN-62] Fix time logging issue while doing reservation

### DIFF
--- a/pkg/scheduler/scheduling_application.go
+++ b/pkg/scheduler/scheduling_application.go
@@ -63,7 +63,7 @@ func newSchedulingApplication(appInfo *cache.ApplicationInfo) *SchedulingApplica
 // override reservation delay for tests
 func OverrideReservationDelay(delay time.Duration) {
 	log.Logger().Debug("Test override reservation delay",
-		zap.Duration("delay", delay))
+		zap.String("delay", delay.String()))
 	reservationDelay = delay
 }
 

--- a/pkg/scheduler/scheduling_application.go
+++ b/pkg/scheduler/scheduling_application.go
@@ -528,9 +528,9 @@ func (sa *SchedulingApplication) tryNodes(ask *schedulingAllocationAsk, nodeIter
 		if askAge > reservationDelay {
 			log.Logger().Debug("app reservation check",
 				zap.String("allocationKey", allocKey),
-				zap.Time("createTime", ask.getCreateTime()),
-				zap.Duration("askAge", askAge),
-				zap.Duration("reservationDelay", reservationDelay))
+				zap.String("createTime", ask.getCreateTime().String()),
+				zap.Float64("askAge", askAge.Seconds()),
+				zap.String("reservationDelay", reservationDelay.String()))
 			score := ask.AllocatedResource.FitInScore(node.GetAvailableResource())
 			// Record the so-far best node to reserve
 			if score < scoreReserved {


### PR DESCRIPTION
Looks like we are hitting some bug in zap, replacing duration with string and this error goes away

```
2020-03-27T13:30:26.553-0700	WARN	predicates/predictor.go:286	predicate failed	{"key": "CheckNodeUnschedulable", "fit": false, "reasons": [{"PredicateName":"NodeUnknownCondition","PredicateDesc":"node(s) had unknown conditions"}]}
2020-03-27T13:30:26.553-0700	DEBUG	scheduler/scheduling_node.go:213	running predicates failed	{"allocationId": "c7ed4d67-7069-11ea-b2f0-025000000001", "nodeID": "docker-desktop", "error": "predicate CheckNodeUnschedulable cannot be satisified, reason [Predicate NodeUnknownCondition failed]"}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x11ac568]

goroutine 51 [running]:
go.uber.org/zap/zapcore.(*jsonEncoder).AppendDuration(0xc007eca390, 0x77370eba)
	/Users/wyang/go/pkg/mod/go.uber.org/zap@v1.13.0/zapcore/json_encoder.go:239 +0xc8
go.uber.org/zap/zapcore.(*jsonEncoder).AddDuration(0xc007eca390, 0x2c60b0f, 0x6, 0x77370eba)
	/Users/wyang/go/pkg/mod/go.uber.org/zap@v1.13.0/zapcore/json_encoder.go:123 +0x65
go.uber.org/zap/zapcore.Field.AddTo(0x2c60b0f, 0x6, 0x8, 0x77370eba, 0x0, 0x0, 0x0, 0x0, 0x2fd78c0, 0xc007eca390)
	/Users/wyang/go/pkg/mod/go.uber.org/zap@v1.13.0/zapcore/field.go:126 +0x558
go.uber.org/zap/zapcore.addFields(0x2fd78c0, 0xc007eca390, 0xc00016e000, 0x4, 0x4)
	/Users/wyang/go/pkg/mod/go.uber.org/zap@v1.13.0/zapcore/field.go:199 +0x114
go.uber.org/zap/zapcore.consoleEncoder.writeContext(0xc0000c1ec0, 0xc007e0ace0, 0xc00016e000, 0x4, 0x4)
	/Users/wyang/go/pkg/mod/go.uber.org/zap@v1.13.0/zapcore/console_encoder.go:131 +0xff
go.uber.org/zap/zapcore.consoleEncoder.EncodeEntry(0xc0000c1ec0, 0xff, 0xbf97b678a0fc80f8, 0x95cef19f3, 0x3f4a2a0, 0x0, 0x0, 0x2c72aac, 0x15, 0x1, ...)
	/Users/wyang/go/pkg/mod/go.uber.org/zap@v1.13.0/zapcore/console_encoder.go:110 +0x47e
go.uber.org/zap/zapcore.(*ioCore).Write(0xc0000c1ef0, 0xff, 0xbf97b678a0fc80f8, 0x95cef19f3, 0x3f4a2a0, 0x0, 0x0, 0x2c72aac, 0x15, 0x1, ...)
	/Users/wyang/go/pkg/mod/go.uber.org/zap@v1.13.0/zapcore/core.go:86 +0x107
go.uber.org/zap/zapcore.(*CheckedEntry).Write(0xc007e52b00, 0xc00016e000, 0x4, 0x4)
	/Users/wyang/go/pkg/mod/go.uber.org/zap@v1.13.0/zapcore/entry.go:216 +0x1e8
go.uber.org/zap.(*Logger).Debug(0xc0005265a0, 0x2c72aac, 0x15, 0xc00016e000, 0x4, 0x4)
	/Users/wyang/go/pkg/mod/go.uber.org/zap@v1.13.0/logger.go:179 +0x96
github.com/apache/incubator-yunikorn-core/pkg/scheduler.(*SchedulingApplication).tryNodes(0xc000314360, 0xc006024000, 0x2f7e3e0, 0xc007d0d600, 0x0)
	/Users/wyang/go/pkg/mod/github.com/apache/incubator-yunikorn-core@v0.0.0-20200327185421-18d6381b4f86/pkg/scheduler/scheduling_application.go:529 +0x7ed
github.com/apache/incubator-yunikorn-core/pkg/scheduler.(*SchedulingApplication).tryAllocate(0xc000314360, 0xc00a2006e8, 0xc0001701c0, 0x0)
	/Users/wyang/go/pkg/mod/github.com/apache/incubator-yunikorn-core@v0.0.0-20200327185421-18d6381b4f86/pkg/scheduler/scheduling_application.go:399 +0x176
github.com/apache/incubator-yunikorn-core/pkg/scheduler.(*SchedulingQueue).tryAllocate(0xc000530e00, 0xc0001701c0, 0x1)
	/Users/wyang/go/pkg/mod/github.com/apache/incubator-yunikorn-core@v0.0.0-20200327185421-18d6381b4f86/pkg/scheduler/scheduling_queue.go:517 +0x139
github.com/apache/incubator-yunikorn-core/pkg/scheduler.(*SchedulingQueue).tryAllocate(0xc000170150, 0xc0001701c0, 0x0)
	/Users/wyang/go/pkg/mod/github.com/apache/incubator-yunikorn-core@v0.0.0-20200327185421-18d6381b4f86/pkg/scheduler/scheduling_queue.go:529 +0x6c8
github.com/apache/incubator-yunikorn-core/pkg/scheduler.(*partitionSchedulingContext).tryAllocate(0xc0001701c0, 0xc00a2006d8)
	/Users/wyang/go/pkg/mod/github.com/apache/incubator-yunikorn-core@v0.0.0-20200327185421-18d6381b4f86/pkg/scheduler/scheduling_partition.go:366 +0x94
github.com/apache/incubator-yunikorn-core/pkg/scheduler.(*Scheduler).schedule(0xc0000e6050)
	/Users/wyang/go/pkg/mod/github.com/apache/incubator-yunikorn-core@v0.0.0-20200327185421-18d6381b4f86/pkg/scheduler/scheduler.go:581 +0x90b
github.com/apache/incubator-yunikorn-core/pkg/scheduler.(*Scheduler).internalSchedule(0xc0000e6050)
	/Users/wyang/go/pkg/mod/github.com/apache/incubator-yunikorn-core@v0.0.0-20200327185421-18d6381b4f86/pkg/scheduler/scheduler.go:101 +0x39
created by github.com/apache/incubator-yunikorn-core/pkg/scheduler.(*Scheduler).StartService
	/Users/wyang/go/pkg/mod/github.com/apache/incubator-yunikorn-core@v0.0.0-20200327185421-18d6381b4f86/pkg/scheduler/scheduler.go:74 +0x1b2
make: *** [run] Error 2
```