### PR TITLE
[YUNIKORN-64] fix zap config creation

### DIFF
--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -43,7 +43,7 @@ func Logger() *zap.Logger {
 			logger, err = config.Build()
 			// this should really not happen so just write to stdout and set a Nop logger
 			if err != nil {
-				fmt.Printf("Logging disabled, logger init failed with error: %v", err)
+				fmt.Printf("Logging disabled, logger init failed with error: %v\n", err)
 				logger = zap.NewNop()
 			}
 		}

--- a/pkg/log/logger_test.go
+++ b/pkg/log/logger_test.go
@@ -26,7 +26,12 @@ import (
 	"gotest.tools/assert"
 )
 
+// This test sets the global zap logger. This must be undone to make sure no side
+// effects on other tests are caused by running this test.
 func TestIsNopLogger(t *testing.T) {
+	// reset the global vars and zap logger
+	defer resetGlobals()
+
 	testLogger, err := zap.NewDevelopment()
 	if err != nil {
 		t.Fatalf("Dev logger init failed with error: %v", err)
@@ -48,25 +53,40 @@ func TestIsNopLogger(t *testing.T) {
 	assert.Equal(t, false, isNopLogger(zap.L()))
 }
 
+// Since we test the function IsDebugEnabled() we set the logger global var.
+// It has not triggered the once.Do() so we just need to make sure we clean up the
+// global var.
 func TestIsDebugEnabled(t *testing.T) {
-	zapConfigs := zap.Config{
+	// reset the global vars and zap logger
+	defer resetGlobals()
+
+	zapConfig := zap.Config{
 		Level:    zap.NewAtomicLevelAt(zapcore.DebugLevel),
 		Encoding: "console",
 	}
 	var err error
-	logger, err = zapConfigs.Build()
+	logger, err = zapConfig.Build()
 	assert.NilError(t, err, "debug level logger create failed")
 	assert.Equal(t, true, IsDebugEnabled())
 
-	zapConfigs = zap.Config{
+	zapConfig = zap.Config{
 		Level:    zap.NewAtomicLevelAt(zapcore.InfoLevel),
 		Encoding: "console",
 	}
-	logger, err = zapConfigs.Build()
+	logger, err = zapConfig.Build()
 	assert.NilError(t, err, "info level logger create failed")
 	assert.Equal(t, false, IsDebugEnabled())
 }
 
+// reset the global vars and the global logger in zap
+func resetGlobals() {
+	logger = nil
+	config = nil
+	zap.ReplaceGlobals(zap.NewNop())
+}
+
+// This test triggers the once.Do() and will have an impact on other tests in this file.
+// resetGlobals() will not undo the impact this test has.
 func TestCreateConfig(t *testing.T) {
 	// direct call
 	zapConfig := createConfig()
@@ -75,11 +95,12 @@ func TestCreateConfig(t *testing.T) {
 	assert.Equal(t, true, localLogger.Core().Enabled(zap.DebugLevel))
 
 	// indirect call to init logger
-	assert.Assert(t, logger != nil, "standard logger should not have been created")
-	_ = Logger()
-	assert.Assert(t, logger == nil, "standard logger should have been created")
+	assert.Assert(t, logger == nil, "global logger should not have been set %v", logger)
+	localLogger = Logger()
+	assert.Assert(t, localLogger != nil, "returned logger should have been not nil")
+	// default log level is debug
 	assert.Equal(t, true, IsDebugEnabled())
-	// change log level: check config stored and logger create
+	// change log level to info
 	InitAndSetLevel(zap.InfoLevel)
 	assert.Equal(t, false, IsDebugEnabled())
 }

--- a/pkg/log/logger_test.go
+++ b/pkg/log/logger_test.go
@@ -66,3 +66,20 @@ func TestIsDebugEnabled(t *testing.T) {
 	assert.NilError(t, err, "info level logger create failed")
 	assert.Equal(t, false, IsDebugEnabled())
 }
+
+func TestCreateConfig(t *testing.T) {
+	// direct call
+	zapConfig := createConfig()
+	localLogger, err := zapConfig.Build()
+	assert.NilError(t, err, "default config logger create failed")
+	assert.Equal(t, true, localLogger.Core().Enabled(zap.DebugLevel))
+
+	// indirect call to init logger
+	assert.Assert(t, logger != nil, "standard logger should not have been created")
+	_ = Logger()
+	assert.Assert(t, logger == nil, "standard logger should have been created")
+	assert.Equal(t, true, IsDebugEnabled())
+	// change log level: check config stored and logger create
+	InitAndSetLevel(zap.InfoLevel)
+	assert.Equal(t, false, IsDebugEnabled())
+}

--- a/pkg/scheduler/scheduling_application.go
+++ b/pkg/scheduler/scheduling_application.go
@@ -63,7 +63,7 @@ func newSchedulingApplication(appInfo *cache.ApplicationInfo) *SchedulingApplica
 // override reservation delay for tests
 func OverrideReservationDelay(delay time.Duration) {
 	log.Logger().Debug("Test override reservation delay",
-		zap.String("delay", delay.String()))
+		zap.Duration("delay", delay))
 	reservationDelay = delay
 }
 
@@ -528,9 +528,9 @@ func (sa *SchedulingApplication) tryNodes(ask *schedulingAllocationAsk, nodeIter
 		if askAge > reservationDelay {
 			log.Logger().Debug("app reservation check",
 				zap.String("allocationKey", allocKey),
-				zap.String("createTime", ask.getCreateTime().String()),
-				zap.Float64("askAge", askAge.Seconds()),
-				zap.String("reservationDelay", reservationDelay.String()))
+				zap.Time("createTime", ask.getCreateTime()),
+				zap.Duration("askAge", askAge),
+				zap.Duration("reservationDelay", reservationDelay))
 			score := ask.AllocatedResource.FitInScore(node.GetAvailableResource())
 			// Record the so-far best node to reserve
 			if score < scoreReserved {


### PR DESCRIPTION
Zap logger used the default DEV config instead of our own, changing to our config to get full control.
Cleanup of the init code of the logger including test.
This reverts changes from: YUNIKORN-62