### PR TITLE
[YUNIKORN-75] REST API for changing log level

### DIFF
--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -30,6 +30,7 @@ import (
 var once sync.Once
 var logger *zap.Logger
 var config *zap.Config
+var aLevel *zap.AtomicLevel
 
 func Logger() *zap.Logger {
 	once.Do(func() {
@@ -76,13 +77,20 @@ func InitAndSetLevel(level zapcore.Level) {
 	config.Level.SetLevel(level)
 }
 
+func GetAtomicLevel() *zap.AtomicLevel {
+	return aLevel
+}
+
 // Create a log config to keep full control over
 // LogLevel set to DEBUG, Encodes for console, Writes to stderr,
 // Enables development mode (DPanicLevel),
 // Print stack traces for messages at WarnLevel and above
 func createConfig() *zap.Config {
+	atomicLevel := zap.NewAtomicLevelAt(zap.DebugLevel)
+	aLevel = &atomicLevel
+
 	return &zap.Config{
-		Level:       zap.NewAtomicLevelAt(zap.DebugLevel),
+		Level:       atomicLevel,
 		Development: true,
 		Encoding:    "console",
 		EncoderConfig: zapcore.EncoderConfig{

--- a/pkg/webservice/handlers_test.go
+++ b/pkg/webservice/handlers_test.go
@@ -20,13 +20,16 @@ package webservice
 
 import (
     "encoding/json"
-    "github.com/apache/incubator-yunikorn-core/pkg/log"
-    "github.com/apache/incubator-yunikorn-core/pkg/webservice/dao"
-    "go.uber.org/zap/zapcore"
-    "gotest.tools/assert"
     "net/http"
     "strings"
     "testing"
+
+    "gotest.tools/assert"
+
+    "go.uber.org/zap/zapcore"
+
+    "github.com/apache/incubator-yunikorn-core/pkg/log"
+    "github.com/apache/incubator-yunikorn-core/pkg/webservice/dao"
 )
 
 func TestValidateConf(t *testing.T) {

--- a/pkg/webservice/routes.go
+++ b/pkg/webservice/routes.go
@@ -98,6 +98,14 @@ var routes = Routes{
 		GetContainerHistory,
 	},
 
+	// endpoint to set log level
+	Route{
+		"Log",
+		"POST",
+		"/ws/v1/log",
+		ConfigureLogger,
+	},
+
 	// endpoint to retrieve CPU, Memory profiling data,
 	// this works with pprof tool. By default, pprof endpoints
 	// are only registered to http.DefaultServeMux. Here, we

--- a/pkg/webservice/routes.go
+++ b/pkg/webservice/routes.go
@@ -98,7 +98,7 @@ var routes = Routes{
 		GetContainerHistory,
 	},
 
-	// endpoint to set log level
+	// endpoint to set attributes of the logger
 	Route{
 		"Log",
 		"POST",


### PR DESCRIPTION
Exposed REST API for changing the `Logger` object. Currently only supports the log level.