### PR TITLE
[YUNIKORN-79] Internal metrics are unavailable through REST API

### DIFF
--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -265,22 +265,23 @@ func GetContainerHistory(w http.ResponseWriter, r *http.Request) {
 	writeHeaders(w)
 
 	if imHistory != nil {
-		var result []*dao.ContainerHistoryDAOInfo
-		records := imHistory.GetRecords()
-		for _, record := range records {
-			if record == nil {
-				continue
-			}
-			element := &dao.ContainerHistoryDAOInfo{
-				Timestamp:       record.Timestamp.UnixNano(),
-				TotalContainers: strconv.Itoa(record.TotalContainers),
-			}
-			result = append(result, element)
-		}
-		if err := json.NewEncoder(w).Encode(result); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
+		http.Error(w, "Internal metrics collection is not enabled.", http.StatusInternalServerError)
 		return
 	}
-	http.Error(w, "Internal metrics collection is not enabled.", http.StatusInternalServerError)
+	var result []*dao.ContainerHistoryDAOInfo
+	records := imHistory.GetRecords()
+	for _, record := range records {
+		if record == nil {
+			continue
+		}
+		element := &dao.ContainerHistoryDAOInfo{
+			Timestamp:       record.Timestamp.UnixNano(),
+			TotalContainers: strconv.Itoa(record.TotalContainers),
+		}
+		result = append(result, element)
+	}
+	if err := json.NewEncoder(w).Encode(result); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+
 }

--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -241,24 +241,24 @@ func GetApplicationHistory(w http.ResponseWriter, r *http.Request) {
 	writeHeaders(w)
 
 	if imHistory != nil {
-		var result []*dao.ApplicationHistoryDAOInfo
-		records := imHistory.GetRecords()
-		for _, record := range records {
-			if record == nil {
-				continue
-			}
-			element := &dao.ApplicationHistoryDAOInfo{
-				Timestamp:         record.Timestamp.UnixNano(),
-				TotalApplications: strconv.Itoa(record.TotalApplications),
-			}
-			result = append(result, element)
-		}
-		if err := json.NewEncoder(w).Encode(result); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
+		http.Error(w, "Internal metrics collection is not enabled.", http.StatusInternalServerError)
 		return
 	}
-	http.Error(w, "Internal metrics collection is not enabled.", http.StatusInternalServerError)
+	var result []*dao.ApplicationHistoryDAOInfo
+	records := imHistory.GetRecords()
+	for _, record := range records {
+		if record == nil {
+			continue
+		}
+		element := &dao.ApplicationHistoryDAOInfo{
+			Timestamp:         record.Timestamp.UnixNano(),
+			TotalApplications: strconv.Itoa(record.TotalApplications),
+		}
+		result = append(result, element)
+	}
+	if err := json.NewEncoder(w).Encode(result); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
 }
 
 func GetContainerHistory(w http.ResponseWriter, r *http.Request) {

--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -245,7 +245,7 @@ func GetApplicationHistory(w http.ResponseWriter, r *http.Request) {
 		records := imHistory.GetRecords()
 		for _, record := range records {
 			if record == nil {
-				break
+				continue
 			}
 			element := &dao.ApplicationHistoryDAOInfo{
 				Timestamp:         record.Timestamp.UnixNano(),
@@ -256,6 +256,7 @@ func GetApplicationHistory(w http.ResponseWriter, r *http.Request) {
 		if err := json.NewEncoder(w).Encode(result); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
+		return
 	}
 	http.Error(w, "Internal metrics collection is not enabled.", http.StatusInternalServerError)
 }
@@ -268,7 +269,7 @@ func GetContainerHistory(w http.ResponseWriter, r *http.Request) {
 		records := imHistory.GetRecords()
 		for _, record := range records {
 			if record == nil {
-				break
+				continue
 			}
 			element := &dao.ContainerHistoryDAOInfo{
 				Timestamp:       record.Timestamp.UnixNano(),
@@ -279,6 +280,7 @@ func GetContainerHistory(w http.ResponseWriter, r *http.Request) {
 		if err := json.NewEncoder(w).Encode(result); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
+		return
 	}
 	http.Error(w, "Internal metrics collection is not enabled.", http.StatusInternalServerError)
 }


### PR DESCRIPTION
The assumption about the internal data structure was not correct. Let's disable the optimization and also add a return statement before we got to the "Internal Server Error" line.