### PR TITLE
[YUNIKORN-36] Update install/uninstall commands of helm charts based on helm v3

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -9,7 +9,7 @@ They are located in the [deployments](https://github.com/apache/incubator-yuniko
 
 ## Quick Start
 
-The easiest way to get started is to our [helm charts](https://github.com/apache/incubator-yunikorn-k8shim/tree/master/helm-charts) to deploy YuniKorn on an existing Kubernetes cluster.
+The easiest way to get started is to our [helm charts](https://github.com/apache/incubator-yunikorn-k8shim/tree/master/helm-charts) to deploy YuniKorn on an existing Kubernetes cluster. Recommand to use Helm 3 or later versions.
 
 ```shell script
 helm install yunikorn ./yunikorn
@@ -23,7 +23,7 @@ kubectl create namespace yunikorn-ns
 helm install yunikorn ./yunikorn --namespace yunikorn-ns
 ```
 
-Likewise, it's easy to uninstall as following:
+Uninstall yunikorn:
 ```shell script
 helm uninstall yunikorn --namespace yunikorn-ns
 ```

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -12,7 +12,7 @@ They are located in the [deployments](https://github.com/apache/incubator-yuniko
 The easiest way to get started is to our [helm charts](https://github.com/apache/incubator-yunikorn-k8shim/tree/master/helm-charts) to deploy YuniKorn on an existing Kubernetes cluster.
 
 ```shell script
-helm install ./yunikorn
+helm install yunikorn ./yunikorn
 ```
 
 it will firstly create a `configmap` where stores YuniKorn configuration, and then deploy YuniKorn scheduler
@@ -20,7 +20,12 @@ and web UI containers in a pod as a `deployment` in the `default` namespace. If 
 
 ```shell script
 kubectl create namespace yunikorn-ns
-helm install ./yunikorn --namespace yunikorn-ns
+helm install yunikorn ./yunikorn --namespace yunikorn-ns
+```
+
+Likewise, it's easy to uninstall as following:
+```shell script
+helm uninstall yunikorn --namespace yunikorn-ns
 ```
 
 If you don't want to use helm charts, you can find our step-by-step


### PR DESCRIPTION
Now helm v3 is the stable and default version according to helm official website(https://helm.sh/docs/), and there are lots of changes between v2 and v3.
Updates:
(1) Add chart name for install command, otherwise it will fail to install based on helm v3 with error: `Error: must either provide a name or specify --generate-name`
(2) Add description for uninstall command.