### PR TITLE
[YUNIKORN-203] Set unmanaged queue max resource

### DIFF
--- a/pkg/cache/queue_info.go
+++ b/pkg/cache/queue_info.go
@@ -180,6 +180,19 @@ func (qi *QueueInfo) setMaxResource(max *resources.Resource) {
 	qi.maxResource = max.Clone()
 }
 
+// Update the max resource for an unmanaged leaf queue.
+func (qi *QueueInfo) UpdateUnManagedMaxResource(max *resources.Resource) {
+	qi.Lock()
+	defer qi.Unlock()
+
+	if qi.isManaged || !qi.isLeaf {
+		log.Logger().Warn("Trying to set max resources set on a queue that is not an unmanaged leaf",
+			zap.String("queueName", qi.Name))
+		return
+	}
+	qi.maxResource = max
+}
+
 // Return if this is a leaf queue or not
 func (qi *QueueInfo) IsLeafQueue() bool {
 	return qi.isLeaf

--- a/pkg/common/resources/resources.go
+++ b/pkg/common/resources/resources.go
@@ -68,13 +68,13 @@ func NewResourceFromMap(m map[string]Quantity) *Resource {
 }
 
 // Create a new resource from a string.
-// The string must be a json marshalled list of map[string]string.
+// The string must be a json marshalled si.Resource.
 func NewResourceFromString(str string) (*Resource, error) {
-	var resMap map[string]string
-	if err := json.Unmarshal([]byte(str), &resMap); err != nil {
+	var siRes *si.Resource
+	if err := json.Unmarshal([]byte(str), &siRes); err != nil {
 		return nil, err
 	}
-	return NewResourceFromConf(resMap)
+	return NewResourceFromProto(siRes), nil
 }
 
 // Create a new resource from the config map.

--- a/pkg/common/resources/resources.go
+++ b/pkg/common/resources/resources.go
@@ -19,6 +19,7 @@
 package resources
 
 import (
+	"encoding/json"
 	"fmt"
 	"math"
 	"sort"
@@ -64,6 +65,16 @@ func NewResourceFromProto(proto *si.Resource) *Resource {
 
 func NewResourceFromMap(m map[string]Quantity) *Resource {
 	return &Resource{Resources: m}
+}
+
+// Create a new resource from a string.
+// The string must be a json marshalled list of map[string]string.
+func NewResourceFromString(str string) (*Resource, error) {
+	var resMap map[string]string
+	if err := json.Unmarshal([]byte(str), &resMap); err != nil {
+		return nil, err
+	}
+	return NewResourceFromConf(resMap)
 }
 
 // Create a new resource from the config map.

--- a/pkg/common/resources/resources_test.go
+++ b/pkg/common/resources/resources_test.go
@@ -1310,8 +1310,6 @@ func TestCalculateAbsUsedCapacity(t *testing.T) {
 }
 
 func TestNewResourceFromString(t *testing.T) {
-	// emptyResource := NewResource()
-
 	tests := map[string]struct {
 		jsonRes  string
 		fail     bool
@@ -1323,37 +1321,37 @@ func TestNewResourceFromString(t *testing.T) {
 			expected: nil,
 		},
 		"empty json": {
-			jsonRes:  "{}",
+			jsonRes:  "{\"resources\":{}}",
 			fail:     false,
 			expected: NewResource(),
 		},
 		"not a map": {
-			jsonRes:  "error",
+			jsonRes:  "{\"resources\":{error}}",
 			fail:     true,
 			expected: nil,
 		},
 		"illegal json": {
-			jsonRes:  "{\"json invalid\":\"missing curly bracket\"",
+			jsonRes:  "{\"resources\":{\"missing curly bracket\":{\"value\":5}}",
 			fail:     true,
 			expected: nil,
 		},
 		"illegal value": {
-			jsonRes:  "{\"invalid\":\"value error\"}",
+			jsonRes:  "{\"resources\":{\"invalid\":{\"value\":\"error\"}}}",
 			fail:     true,
 			expected: nil,
 		},
 		"simple": {
-			jsonRes:  "{\"valid\":\"10\"}",
+			jsonRes:  "{\"resources\":{\"valid\":{\"value\":10}}}",
 			fail:     false,
 			expected: NewResourceFromMap(map[string]Quantity{"valid": 10}),
 		},
 		"double": {
-			jsonRes:  "{\"valid\":\"10\", \"other\":\"5\"}",
+			jsonRes:  "{\"resources\":{\"valid\":{\"value\":10}, \"other\":{\"value\":5}}}",
 			fail:     false,
 			expected: NewResourceFromMap(map[string]Quantity{"valid": 10, "other": 5}),
 		},
 		"same twice": {
-			jsonRes:  "{\"negative\":\"10\", \"negative\":\"-10\"}",
+			jsonRes:  "{\"resources\":{\"negative\":{\"value\":10}, \"negative\":{\"value\":-10}}}",
 			fail:     false,
 			expected: NewResourceFromMap(map[string]Quantity{"negative": -10}),
 		},

--- a/pkg/common/resources/resources_test.go
+++ b/pkg/common/resources/resources_test.go
@@ -1313,62 +1313,62 @@ func TestNewResourceFromString(t *testing.T) {
 	// emptyResource := NewResource()
 
 	tests := map[string]struct {
-		jsonRes string
-		fail bool
+		jsonRes  string
+		fail     bool
 		expected *Resource
 	}{
 		"empty string": {
-			jsonRes: "",
-			fail: false,
+			jsonRes:  "",
+			fail:     false,
 			expected: nil,
 		},
 		"empty json": {
-			jsonRes: "{}",
-			fail: false,
+			jsonRes:  "{}",
+			fail:     false,
 			expected: NewResource(),
 		},
 		"not a map": {
-			jsonRes: "error",
-			fail: true,
+			jsonRes:  "error",
+			fail:     true,
 			expected: nil,
 		},
 		"illegal json": {
-			jsonRes: "{\"json invalid\":\"missing curly bracket\"",
-			fail: true,
+			jsonRes:  "{\"json invalid\":\"missing curly bracket\"",
+			fail:     true,
 			expected: nil,
 		},
 		"illegal value": {
-			jsonRes: "{\"invalid\":\"value error\"}",
-			fail: true,
+			jsonRes:  "{\"invalid\":\"value error\"}",
+			fail:     true,
 			expected: nil,
 		},
 		"simple": {
-			jsonRes: "{\"valid\":\"10\"}",
-			fail: false,
+			jsonRes:  "{\"valid\":\"10\"}",
+			fail:     false,
 			expected: NewResourceFromMap(map[string]Quantity{"valid": 10}),
 		},
 		"double": {
-			jsonRes: "{\"valid\":\"10\", \"other\":\"5\"}",
-			fail: false,
+			jsonRes:  "{\"valid\":\"10\", \"other\":\"5\"}",
+			fail:     false,
 			expected: NewResourceFromMap(map[string]Quantity{"valid": 10, "other": 5}),
 		},
 		"same twice": {
-			jsonRes: "{\"negative\":\"10\", \"negative\":\"-10\"}",
-			fail: false,
+			jsonRes:  "{\"negative\":\"10\", \"negative\":\"-10\"}",
+			fail:     false,
 			expected: NewResourceFromMap(map[string]Quantity{"negative": -10}),
 		},
 	}
 	for name, test := range tests {
-		fromJson, err := NewResourceFromString(test.jsonRes)
+		fromJSON, err := NewResourceFromString(test.jsonRes)
 		if test.fail {
-			if err == nil || fromJson != nil {
+			if err == nil || fromJSON != nil {
 				t.Errorf("expected error and nil resource for test: %s got results", name)
 			}
 		} else {
-			if test.expected == nil && fromJson != nil {
-				t.Errorf("expected nil resource for test: %s, got: %s", name, fromJson.String())
-			} else if !Equals(fromJson, test.expected) {
-				t.Errorf("returned resource did not match expected resource for test: %s, expected %s, got: %v", name, test.expected, fromJson)
+			if test.expected == nil && fromJSON != nil {
+				t.Errorf("expected nil resource for test: %s, got: %s", name, fromJSON.String())
+			} else if !Equals(fromJSON, test.expected) {
+				t.Errorf("returned resource did not match expected resource for test: %s, expected %s, got: %v", name, test.expected, fromJSON)
 			}
 		}
 	}

--- a/pkg/scheduler/scheduling_application.go
+++ b/pkg/scheduler/scheduling_application.go
@@ -693,6 +693,11 @@ func (sa *SchedulingApplication) isWaiting() bool {
 	return sa.ApplicationInfo.IsWaiting()
 }
 
+// Get a tag from the cache object
+func (sa *SchedulingApplication) getTag(tag string) string {
+	return sa.ApplicationInfo.GetTag(tag)
+}
+
 // Move the app state to running after allocation has been recovered.
 // Since we do not add allocations in the normal way states will not change during recovery.
 // There could also be multiple nodes that recover the app and

--- a/pkg/scheduler/scheduling_queue_test.go
+++ b/pkg/scheduler/scheduling_queue_test.go
@@ -333,7 +333,7 @@ func TestAddApplicationWithTag(t *testing.T) {
 			"first": 10,
 		})
 	tags := make(map[string]string)
-	tags[appTagNamespaceResourceQuota] = "{\"first\":\"10\"}"
+	tags[appTagNamespaceResourceQuota] = "{\"resources\":{\"first\":{\"value\":10}}}"
 	// add apps again now with the tag set
 	appInfo = cache.NewApplicationInfo("app-3", "default", "root.leaf-man", security.UserGroup{}, tags)
 	app3 := newSchedulingApplication(appInfo)
@@ -351,7 +351,7 @@ func TestAddApplicationWithTag(t *testing.T) {
 	}
 
 	// set to illegal limit (0 value)
-	tags[appTagNamespaceResourceQuota] = "{\"first\":\"0\"}"
+	tags[appTagNamespaceResourceQuota] = "{\"resources\":{\"first\":{\"value\":0}}}"
 	appInfo = cache.NewApplicationInfo("app-4", "default", "root.leaf-un", security.UserGroup{}, tags)
 	app4 = newSchedulingApplication(appInfo)
 	leafUn.addSchedulingApplication(app4)


### PR DESCRIPTION
Set the unmanaged max queue resource based on the tag that is passed in
with a new application. The tag represents the quota from a namespace
from k8s. The max resource is only set on an unmanaged leaf queue as
the functionality should be used with the tag based placement rule.

This works around the hard namespace quota in k8s without the need for
major changes on the side of k8s namespace management.

The tag that is used is "namespace.resourcequota".