### PR TITLE
[YUNIKORN-261] add request sorting policy

### DIFF
--- a/docs/sorting_policy.md
+++ b/docs/sorting_policy.md
@@ -143,8 +143,45 @@ This results in a node with the highest utilisation to be considered first for a
 Resulting in a high(er) utilisation of a small(er) number of nodes, better suited for cloud deployments.   
 
 ## Request sorting
-There is currently one policy for sorting requests within an application.
-This policy is not configurable.
-Sorting requests is only possible based on the priority of the request.
-If there are multiple requests within an application that have the same priority the order of the requests is undetermined.
-This means that the order of requests with the same priority can, and most likely will, change between runs.
+There are currently two policies for sorting requests within an application.
+A request is an ask from an application which maps to one or more pods or containers.
+The policy is not set directly on the application but inherited from the queue. 
+A sorting policy setting is only effective on a `leaf` queue.
+Each `leaf` queue can use a different policy.
+
+Requests are sorted but this is not a guarantee that a newer request will not be allocated before an older request.
+There might be cases that a request cannot be allocated immediately.
+In that case is a newer request might be allocated before an older request (i.e. a reservation for an old request).  
+
+The following configuration entry sets the request sorting policy to `priority` for the queue `root.sandbox`: 
+```yaml
+partitions:
+  - name: default
+    queues:
+    - name: root
+      queues:
+      - name: sandbox
+        properties:
+          request.sort.policy: priority
+```
+
+### FifoSortPolicy
+Short description: first in first out, based on application create time  
+Config value: fifo (default)  
+Behaviour:  
+Before sorting the requests are filtered and must have pending asks.
+
+Requests are sorted based on the time the request was created only.
+The oldest request will be considered first.
+
+### PrioritySortPolicy
+Short description: sort requests from highest to the lowest   
+Config value: priority  
+Behaviour:  
+Before sorting the requests are filtered and must have pending asks.
+
+Priority is a non-negative integer number.
+Zero (0) is considered the lowest priority in the range. 
+
+Requests with the same priority for one application are sorted based on the time the request was created.
+Within a priority requests are thus always considered in a first in first out order.

--- a/docs/sorting_policy.md
+++ b/docs/sorting_policy.md
@@ -175,7 +175,7 @@ Requests are sorted based on the time the request was created only.
 The oldest request will be considered first.
 
 ### PrioritySortPolicy
-Short description: sort requests from highest to the lowest   
+Short description: sorts requests from highest to the lowest priority   
 Config value: priority  
 Behaviour:  
 Before sorting the requests are filtered and must have pending asks.

--- a/docs/sorting_policy.md
+++ b/docs/sorting_policy.md
@@ -143,15 +143,19 @@ This results in a node with the highest utilisation to be considered first for a
 Resulting in a high(er) utilisation of a small(er) number of nodes, better suited for cloud deployments.   
 
 ## Request sorting
-There are currently two policies for sorting requests within an application.
 A request is an ask from an application which maps to one or more pods or containers.
+The number of pods or containers is specified by the repeat specified in the request.
+Pending repeats on a request are pending resources for an application.
+A sorting policy only specifies the order in which the requests are sorted within an application.
+
+There are currently two policies for sorting requests within an application.
 The policy is not set directly on the application but inherited from the queue. 
 A sorting policy setting is only effective on a `leaf` queue.
 Each `leaf` queue can use a different policy.
 
 Requests are sorted but this is not a guarantee that a newer request will not be allocated before an older request.
-There might be cases that a request cannot be allocated immediately.
-In that case is a newer request might be allocated before an older request (i.e. a reservation for an old request).  
+There might be a case that a request cannot be allocated immediately.
+In that case a newer request might be allocated before an older request (i.e. a reservation for an old request).  
 
 The following configuration entry sets the request sorting policy to `priority` for the queue `root.sandbox`: 
 ```yaml
@@ -169,19 +173,19 @@ partitions:
 Short description: first in first out, based on application create time  
 Config value: fifo (default)  
 Behaviour:  
-Before sorting the requests are filtered and must have pending asks.
+Before sorting the requests are filtered and must have pending repeats.
 
-Requests are sorted based on the time the request was created only.
-The oldest request will be considered first.
+Requests are sorted based on the time the request was created.
+The oldest request will be considered first by the scheduler.
 
 ### PrioritySortPolicy
 Short description: sorts requests from highest to the lowest priority   
 Config value: priority  
 Behaviour:  
-Before sorting the requests are filtered and must have pending asks.
+Before sorting the requests are filtered and must have pending repeats.
 
 Priority is a non-negative integer number.
 Zero (0) is considered the lowest priority in the range. 
 
-Requests with the same priority for one application are sorted based on the time the request was created.
+Requests with the same priority are sorted based on the time the request was created.
 Within a priority requests are thus always considered in a first in first out order.

--- a/go.sum
+++ b/go.sum
@@ -5,9 +5,6 @@ github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuy
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
-github.com/apache/incubator-yunikorn-scheduler-interface v0.0.0-20200414171840-a773cd557b1f h1:MO1PV62hmeaahOItQq848+aSbypnjdtXj4k0v+O4+nI=
-github.com/apache/incubator-yunikorn-scheduler-interface v0.0.0-20200414171840-a773cd557b1f/go.mod h1:De+73NNH4KaRL9MGGnCyHJOtx2oQGVYOaespfoRNGSo=
-github.com/apache/incubator-yunikorn-scheduler-interface v0.8.0 h1:6gmLqBsnbUHbbd73GioZTqoXNbLXB7LPnFN9Qk6QpwU=
 github.com/apache/incubator-yunikorn-scheduler-interface v0.8.1-0.20200613000533-a889c9d6bafc h1:8VlHGRc+XaZ27zir8FZ7h/nkhonYK8jpUTT9KP5cTnk=
 github.com/apache/incubator-yunikorn-scheduler-interface v0.8.1-0.20200613000533-a889c9d6bafc/go.mod h1:t1x4L4P6YzNYRhZjQg7qAd/RM8ICaXZ1vo16SimxVes=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/pkg/cache/application_info.go
+++ b/pkg/cache/application_info.go
@@ -41,7 +41,7 @@ type ApplicationInfo struct {
 	ApplicationID  string
 	Partition      string
 	QueueName      string
-	SubmissionTime int64
+	SubmissionTime time.Time
 
 	// Private fields need protection
 	user              security.UserGroup         // owner of the application
@@ -61,7 +61,7 @@ func NewApplicationInfo(appID, partition, queueName string, ugi security.UserGro
 		ApplicationID:     appID,
 		Partition:         partition,
 		QueueName:         queueName,
-		SubmissionTime:    time.Now().UnixNano(),
+		SubmissionTime:    time.Now(),
 		tags:              tags,
 		user:              ugi,
 		allocatedResource: resources.NewResource(),
@@ -256,6 +256,6 @@ func (ai *ApplicationInfo) GetTag(tag string) string {
 func (ai *ApplicationInfo) String() string {
 	ai.RLock()
 	defer ai.RUnlock()
-	return fmt.Sprintf("{ApplicationID: %s, Partition: %s, QueueName: %s, SubmissionTime: %x}",
-		ai.ApplicationID, ai.Partition, ai.QueueName, ai.SubmissionTime)
+	return fmt.Sprintf("{ApplicationID: %s, Partition: %s, QueueName: %s, SubmissionTime: %s}",
+		ai.ApplicationID, ai.Partition, ai.QueueName, ai.SubmissionTime.String())
 }

--- a/pkg/common/configs/configvalidator.go
+++ b/pkg/common/configs/configvalidator.go
@@ -36,6 +36,8 @@ const (
 	DefaultPartition = "default"
 	// How to sort applications in leaf queues, valid options are defined in the scheduler.policies
 	ApplicationSortPolicy = "application.sort.policy"
+	// How to sort tasks in an application, valid options are defined in the scheduler.policies
+	RequestSortPolicy = "request.sort.policy"
 )
 
 // A queue can be a username with the dot replaced. Most systems allow a 32 character user name.

--- a/pkg/scheduler/policies/sorting_policy.go
+++ b/pkg/scheduler/policies/sorting_policy.go
@@ -26,14 +26,15 @@ import (
 type SortPolicy int
 
 const (
-	FifoSortPolicy   SortPolicy = iota // first in first out, submit time
+	Undefined        SortPolicy = iota // not initialised or parsing failed
+	FifoSortPolicy                     // first in first out, submit time
 	FairSortPolicy                     // fair based on usage
 	StateAwarePolicy                   // only 1 app in starting state
-	Undefined                          // not initialised or parsing failed
+	PriorityPolicy                     // sort on the priority
 )
 
 func (s SortPolicy) String() string {
-	return [...]string{"fifo", "fair", "stateaware", "undefined"}[s]
+	return [...]string{"undefined", "fifo", "fair", "stateaware", "priority"}[s]
 }
 
 func SortPolicyFromString(str string) (SortPolicy, error) {
@@ -45,6 +46,8 @@ func SortPolicyFromString(str string) (SortPolicy, error) {
 		return FairSortPolicy, nil
 	case StateAwarePolicy.String():
 		return StateAwarePolicy, nil
+	case PriorityPolicy.String():
+		return PriorityPolicy, nil
 	default:
 		return Undefined, fmt.Errorf("undefined policy: %s", str)
 	}

--- a/pkg/scheduler/policies/sorting_policy_test.go
+++ b/pkg/scheduler/policies/sorting_policy_test.go
@@ -33,6 +33,7 @@ func TestAppFromString(t *testing.T) {
 		{"FifoString", "fifo", FifoSortPolicy, false},
 		{"FairString", "fair", FairSortPolicy, false},
 		{"StatusString", "stateaware", StateAwarePolicy, false},
+		{"PriorityString", "priority", PriorityPolicy, false},
 		{"UnknownString", "unknown", Undefined, true},
 	}
 	for _, tt := range tests {
@@ -57,8 +58,9 @@ func TestAppToString(t *testing.T) {
 		{"FifoString", FifoSortPolicy, "fifo"},
 		{"FairString", FairSortPolicy, "fair"},
 		{"StatusString", StateAwarePolicy, "stateaware"},
+		{"PriorityString", PriorityPolicy, "priority"},
 		{"DefaultString", Undefined, "undefined"},
-		{"NoneString", someSP, "fifo"},
+		{"NoneString", someSP, "undefined"},
 	}
 	for _, tt := range tests {
 		if got := tt.sp.String(); got != tt.want {

--- a/pkg/scheduler/scheduling_allocation_ask.go
+++ b/pkg/scheduler/scheduling_allocation_ask.go
@@ -108,9 +108,15 @@ func (saa *schedulingAllocationAsk) getCreateTime() time.Time {
 	return saa.createTime
 }
 
-// Normalised priority
-// Currently a direct conversion.
+// Normalised priority, a direct conversion with a minimal value of 0.
+// 0 is the lowest priority
+// MaxInt the highest.
+// No support for named priorities
 func (saa *schedulingAllocationAsk) normalizePriority(priority *si.Priority) int32 {
 	// TODO, really normalize priority from ask
-	return priority.GetPriorityValue()
+	prioVal := priority.GetPriorityValue()
+	if prioVal < 0 {
+		return 0
+	}
+	return prioVal
 }

--- a/pkg/scheduler/scheduling_allocation_ask_test.go
+++ b/pkg/scheduler/scheduling_allocation_ask_test.go
@@ -73,3 +73,26 @@ func TestGetCreateTime(t *testing.T) {
 		t.Fatal("create time stamp should have been modified")
 	}
 }
+
+// Check priority defaults and normalisation
+func TestPriority(t *testing.T) {
+	ask := &si.AllocationAsk{}
+	allocAsk := newSchedulingAllocationAsk(ask)
+	if allocAsk == nil {
+		t.Fatalf("empty ask proto should not fail creation")
+	}
+	priority := int32(0)
+	assert.Equal(t, allocAsk.priority, priority, "priority should default to 0 value")
+
+	ask = &si.AllocationAsk{
+		Priority: &si.Priority{Priority: &si.Priority_PriorityValue{PriorityValue: int32(-1)}},
+	}
+	allocAsk = newSchedulingAllocationAsk(ask)
+	assert.Equal(t, allocAsk.priority, priority, "priority should have been normalised (min value 0)")
+	priority = int32(100)
+	ask = &si.AllocationAsk{
+		Priority: &si.Priority{Priority: &si.Priority_PriorityValue{PriorityValue: priority}},
+	}
+	allocAsk = newSchedulingAllocationAsk(ask)
+	assert.Equal(t, allocAsk.priority, priority, "priority should have been set to 100")
+}

--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -201,7 +201,7 @@ func getApplicationJSON(app *cache.ApplicationInfo) *dao.ApplicationDAOInfo {
 		UsedResource:   strings.Trim(app.GetAllocatedResource().String(), "map"),
 		Partition:      app.Partition,
 		QueueName:      app.QueueName,
-		SubmissionTime: app.SubmissionTime,
+		SubmissionTime: app.SubmissionTime.UnixNano(),
 		Allocations:    allocationInfos,
 		State:          app.GetApplicationState(),
 	}


### PR DESCRIPTION
Add a request sorting policy per queue for requests in an application.
The policy is set on a leaf queue using "request.sort.policy". The policies
supported are FIFO (default) and priority.
FIFO sorts based on the create time of the request. Priority sorts requests
in a descending order. Requests that have the same priority are sorted FIFO
within the set of requests with the same priority.

Priorities range from 0 (lowest) to 2147483647 (maximum).

Internal change: application submit time is no longer stored as an integer
but as a time object equivalent to requests.