### PR TITLE
[YUNIKORN-241] priority sorting quick fix

### DIFF
--- a/pkg/scheduler/sorters.go
+++ b/pkg/scheduler/sorters.go
@@ -152,6 +152,10 @@ func sortAskByPriority(requests []*schedulingAllocationAsk, ascending bool) {
 		l := requests[i]
 		r := requests[j]
 
+		if l.priority == r.priority {
+			return l.createTime.Before(r.createTime)
+		}
+
 		if ascending {
 			return l.priority < r.priority
 		}

--- a/pkg/scheduler/sorters_test.go
+++ b/pkg/scheduler/sorters_test.go
@@ -458,10 +458,10 @@ func TestSortAsks(t *testing.T) {
 	list[0].priority = 1
 	sortAskByPriority(list, true)
 	// asks should come back in order: 0, 2, 3, 1
-	assertAskList(t, list, []int{0, 2, 3, 1})
+	assertAskList(t, list, []int{0, 1, 3, 2})
 	sortAskByPriority(list, false)
 	// asks should come back in order: 3, 2, 0, 1
-	assertAskList(t, list, []int{3, 2, 0, 1})
+	assertAskList(t, list, []int{3, 1, 0, 2})
 }
 
 // list of queues and the location of the named queue inside that list


### PR DESCRIPTION
Quick fix to change priority sorting to FIFO sorting for requests based on
the fact that the shim does not set priority.
