### PR TITLE
[YUNIKORN-302] use same reservation delay in all tests

### DIFF
--- a/pkg/scheduler/scheduling_partition_test.go
+++ b/pkg/scheduler/scheduling_partition_test.go
@@ -335,7 +335,7 @@ func TestTryAllocateLarge(t *testing.T) {
 	}
 
 	// override the reservation delay, and cleanup when done
-	OverrideReservationDelay(time.Nanosecond)
+	OverrideReservationDelay(10 * time.Nanosecond)
 	defer OverrideReservationDelay(2 * time.Second)
 
 	leaf := partition.getQueue("root.parent.leaf1")
@@ -376,7 +376,7 @@ func TestAllocReserveNewNode(t *testing.T) {
 	}
 
 	// override the reservation delay, and cleanup when done
-	OverrideReservationDelay(time.Nanosecond)
+	OverrideReservationDelay(10 * time.Nanosecond)
 	defer OverrideReservationDelay(2 * time.Second)
 
 	// turn off the second node
@@ -603,7 +603,7 @@ func TestScheduleRemoveReservedAsk(t *testing.T) {
 	}
 
 	// override the reservation delay, and cleanup when done
-	OverrideReservationDelay(time.Nanosecond)
+	OverrideReservationDelay(10 * time.Nanosecond)
 	defer OverrideReservationDelay(2 * time.Second)
 
 	leaf := partition.getQueue("root.parent.leaf1")

--- a/pkg/scheduler/tests/scheduler_reservation_test.go
+++ b/pkg/scheduler/tests/scheduler_reservation_test.go
@@ -88,7 +88,7 @@ func TestBasicReservation(t *testing.T) {
 	assert.NilError(t, err, "RegisterResourceManager failed")
 
 	// override the reservation delay, and cleanup when done
-	scheduler.OverrideReservationDelay(10 * time.Millisecond)
+	scheduler.OverrideReservationDelay(10 * time.Nanosecond)
 	defer scheduler.OverrideReservationDelay(2 * time.Second)
 
 	nodes := createNodes(t, ms, 2, 50)
@@ -166,7 +166,7 @@ func TestReservationForTwoQueues(t *testing.T) {
 	err := ms.Init(DualQueueConfig, false)
 	assert.NilError(t, err, "RegisterResourceManager failed")
 	// override the reservation delay, and cleanup when done
-	scheduler.OverrideReservationDelay(10 * time.Millisecond)
+	scheduler.OverrideReservationDelay(10 * time.Nanosecond)
 	defer scheduler.OverrideReservationDelay(2 * time.Second)
 
 	nodes := createNodes(t, ms, 2, 50)
@@ -276,7 +276,7 @@ func TestRemoveReservedNode(t *testing.T) {
 	err := ms.Init(SingleQueueConfig, false)
 	assert.NilError(t, err, "RegisterResourceManager failed")
 	// override the reservation delay, and cleanup when done
-	scheduler.OverrideReservationDelay(10 * time.Millisecond)
+	scheduler.OverrideReservationDelay(10 * time.Nanosecond)
 	defer scheduler.OverrideReservationDelay(2 * time.Second)
 
 	nodes := createNodes(t, ms, 2, 50)
@@ -331,7 +331,7 @@ func TestAddNewNode(t *testing.T) {
 	assert.NilError(t, err, "RegisterResourceManager failed")
 
 	// override the reservation delay, and cleanup when done
-	scheduler.OverrideReservationDelay(10 * time.Millisecond)
+	scheduler.OverrideReservationDelay(10 * time.Nanosecond)
 	defer scheduler.OverrideReservationDelay(2 * time.Second)
 
 	nodes := createNodes(t, ms, 3, 50)
@@ -392,7 +392,7 @@ func TestUnReservationAndDeletion(t *testing.T) {
 	assert.NilError(t, err, "RegisterResourceManager failed")
 
 	// override the reservation delay, and cleanup when done
-	scheduler.OverrideReservationDelay(10 * time.Millisecond)
+	scheduler.OverrideReservationDelay(10 * time.Nanosecond)
 	defer scheduler.OverrideReservationDelay(2 * time.Second)
 
 	nodes := createNodes(t, ms, 2, 30)


### PR DESCRIPTION
The reservation delay in certain tests is set to 10msec. This is on the
edge of being too long for a number of tests. It can cause unexpected
failures if the system the unit tests run on is "fast".