### PR TITLE
[YUNIKORN-273] expose config via rest

### DIFF
--- a/pkg/cache/cluster_info.go
+++ b/pkg/cache/cluster_info.go
@@ -146,6 +146,14 @@ func enqueueAndCheckFull(queue chan interface{}, ev interface{}) {
 	}
 }
 
+// Get the config name.
+// Locked call, used outside of the cache.
+func (m *ClusterInfo) GetPolicyGroup() string {
+	m.RLock()
+	defer m.RUnlock()
+	return m.policyGroup
+}
+
 // Get the list of partitions.
 // Locked call, used outside of the cache.
 func (m *ClusterInfo) ListPartitions() []string {
@@ -461,9 +469,6 @@ func (m *ClusterInfo) processRMRegistrationEvent(event *commonevents.RegisterRME
 	for _, u := range updatedPartitions {
 		updatedPartitionsInterfaces = append(updatedPartitionsInterfaces, u)
 	}
-
-	// Keep track of the config, cannot be changed for this RM
-	m.policyGroup = event.RMRegistrationRequest.PolicyGroup
 
 	// Send updated partitions to scheduler
 	m.EventHandlers.SchedulerEventHandler.HandleEvent(&schedulerevent.SchedulerUpdatePartitionsConfigEvent{

--- a/pkg/cache/initializer.go
+++ b/pkg/cache/initializer.go
@@ -66,14 +66,15 @@ func SetClusterInfoFromConfigFile(clusterInfo *ClusterInfo, rmID string, policyG
 		return []*PartitionInfo{}, err
 	}
 
-	// update global scheduler configs
-	configs.ConfigContext.Set(policyGroup, conf)
-
-	updatedPartitions, err := createPartitionInfos(clusterInfo, conf, rmID)
-
+	var updatedPartitions []*PartitionInfo
+	updatedPartitions, err = createPartitionInfos(clusterInfo, conf, rmID)
 	if err != nil {
 		return []*PartitionInfo{}, err
 	}
+
+	// update global scheduler configs, set the policyGroup for this cluster
+	clusterInfo.policyGroup = policyGroup
+	configs.ConfigContext.Set(policyGroup, conf)
 
 	return updatedPartitions, nil
 }

--- a/pkg/common/configs/config.go
+++ b/pkg/common/configs/config.go
@@ -35,7 +35,7 @@ import (
 // set of scheduler resources.
 type SchedulerConfig struct {
 	Partitions []PartitionConfig
-	Checksum   []byte
+	Checksum   [32]byte `yaml:"-" json:"-"`
 }
 
 // The partition object for each partition:
@@ -157,8 +157,8 @@ func LoadSchedulerConfigFromByteArray(content []byte) (*SchedulerConfig, error) 
 		return nil, err
 	}
 
-	h := sha256.New()
-	conf.Checksum = h.Sum(content)
+	// h := sha256.New()
+	conf.Checksum = sha256.Sum256(content)
 	return conf, err
 }
 

--- a/pkg/common/configs/config.go
+++ b/pkg/common/configs/config.go
@@ -157,7 +157,7 @@ func LoadSchedulerConfigFromByteArray(content []byte) (*SchedulerConfig, error) 
 		return nil, err
 	}
 
-	// h := sha256.New()
+	// Create a sha256 checksum for this validated config
 	conf.Checksum = sha256.Sum256(content)
 	return conf, err
 }

--- a/pkg/common/configs/config_test.go
+++ b/pkg/common/configs/config_test.go
@@ -30,6 +30,8 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+var emptySum = [32]byte{}
+
 func TestConfigSerdeQueues(t *testing.T) {
 	conf := SchedulerConfig{
 		Partitions: []PartitionConfig{
@@ -121,7 +123,7 @@ func TestConfigSerdeQueues(t *testing.T) {
 				},
 			},
 		},
-		Checksum: []byte(""),
+		Checksum: emptySum,
 	}
 
 	SerdeTest(t, conf, "QueueConfig")
@@ -186,7 +188,7 @@ func TestConfigSerdeLimits(t *testing.T) {
 				},
 			},
 		},
-		Checksum: []byte(""),
+		Checksum: emptySum,
 	}
 
 	SerdeTest(t, conf, "LimitConfig")

--- a/pkg/common/configs/configwatcher.go
+++ b/pkg/common/configs/configwatcher.go
@@ -79,6 +79,7 @@ func (cw *ConfigWatcher) RegisterCallback(reloader ConfigReloader) {
 // returns true if config file state remains same,
 // returns false if config file state changes
 func (cw *ConfigWatcher) runOnce() bool {
+	// acquire the lock to avoid Checksum changed externally
 	cw.lock.Lock()
 	defer cw.lock.Unlock()
 
@@ -89,9 +90,7 @@ func (cw *ConfigWatcher) runOnce() bool {
 		return false
 	}
 
-	// acquire the lock to avoid Checksum changed externally
-	same := bytes.Equal(newConfig.Checksum, ConfigContext.Get(cw.policyGroup).Checksum)
-	if same {
+	if bytes.Equal(newConfig.Checksum[:], ConfigContext.Get(cw.policyGroup).Checksum[:]) {
 		// check sum equals, file not changed
 		time.Sleep(1 * time.Second)
 		return true

--- a/pkg/common/configs/configwatcher_test.go
+++ b/pkg/common/configs/configwatcher_test.go
@@ -49,11 +49,12 @@ func (r *FakeConfigReloader) DoReloadConfiguration() error {
 // it verifies the callback is not triggered until file state changes.
 func TestTriggerCallback(t *testing.T) {
 	var timesOfChecksum int
+	var modifiedSum = [32]byte{65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 48, 49, 50, 51, 52, 53}
 	// init context
-	ConfigContext.Set("p-group", &SchedulerConfig{Checksum: []byte("abc")})
+	ConfigContext.Set("p-group", &SchedulerConfig{Checksum: emptySum})
 	SchedulerConfigLoader = func(policyGroup string) (config *SchedulerConfig, e error) {
 		timesOfChecksum++
-		return &SchedulerConfig{Checksum: []byte("abc")}, nil
+		return &SchedulerConfig{Checksum: emptySum}, nil
 	}
 
 	// the original Checksum
@@ -76,7 +77,7 @@ func TestTriggerCallback(t *testing.T) {
 	// simulate file state changes
 	SchedulerConfigLoader = func(policyGroup string) (config *SchedulerConfig, e error) {
 		timesOfChecksum++
-		return &SchedulerConfig{Checksum: []byte("bcd")}, nil
+		return &SchedulerConfig{Checksum: modifiedSum}, nil
 	}
 
 	cw.runOnce()
@@ -125,10 +126,10 @@ func TestChecksumFailure(t *testing.T) {
 
 func TestConfigWatcherExpiration(t *testing.T) {
 	// init conf
-	ConfigContext.Set("p-group", &SchedulerConfig{Checksum: []byte("abc")})
+	ConfigContext.Set("p-group", &SchedulerConfig{Checksum: emptySum})
 	// simulate configuration never changes
 	SchedulerConfigLoader = func(policyGroup string) (config *SchedulerConfig, e error) {
-		return &SchedulerConfig{Checksum: []byte("abc")}, nil
+		return &SchedulerConfig{Checksum: emptySum}, nil
 	}
 	cw := CreateConfigWatcher("rm-id", "p-group", 2*time.Second)
 	cw.Run()

--- a/pkg/scheduler/tests/scheduler_smoke_test.go
+++ b/pkg/scheduler/tests/scheduler_smoke_test.go
@@ -104,7 +104,7 @@ partitions:
 
 	// wait until configuration is reloaded
 	if err = common.WaitFor(time.Second, 5*time.Second, func() bool {
-		return !bytes.Equal(configs.ConfigContext.Get("policygroup").Checksum, configChecksum)
+		return !bytes.Equal(configs.ConfigContext.Get("policygroup").Checksum[:], configChecksum[:])
 	}); err != nil {
 		t.Errorf("timeout waiting for configuration to be reloaded: %v", err)
 	}

--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -296,21 +296,15 @@ func getContainerHistory(w http.ResponseWriter, r *http.Request) {
 
 func getClusterConfig(w http.ResponseWriter, r *http.Request) {
 	writeHeaders(w)
-	jsonOutput := false
-	query := r.URL.Query()
-	// check if we have a request for json output
-	if len(query) != 0 {
-		if _, ok := query["json"]; ok {
-			jsonOutput = true
-		}
-	}
 
+	conf := configs.ConfigContext.Get(gClusterInfo.GetPolicyGroup())
 	var marshalledConf []byte
 	var err error
-	conf := configs.ConfigContext.Get(gClusterInfo.GetPolicyGroup())
-	if jsonOutput {
+	// check if we have a request for json output
+	if r.Header.Get("Accept") == "application/json" {
 		marshalledConf, err = json.Marshal(&conf)
 	} else {
+		w.Header().Set("Content-Type", "application/x-yaml; charset=UTF-8")
 		marshalledConf, err = yaml.Marshal(&conf)
 	}
 	if err != nil {

--- a/pkg/webservice/handlers_test.go
+++ b/pkg/webservice/handlers_test.go
@@ -202,8 +202,8 @@ func TestContainerHistory(t *testing.T) {
 }
 
 func TestGetConfigYAML(t *testing.T) {
-	rmID := "rm-123"
-	policyGroup := "default-policy-group"
+	const rmID = "rm-123"
+	const policyGroup = "default-policy-group"
 	gClusterInfo = cache.NewClusterInfo()
 
 	configs.MockSchedulerConfigByData([]byte(startConf))
@@ -245,8 +245,8 @@ func TestGetConfigYAML(t *testing.T) {
 }
 
 func TestGetConfigJSON(t *testing.T) {
-	rmID := "rm-123"
-	policyGroup := "default-policy-group"
+	const rmID = "rm-123"
+	const policyGroup = "default-policy-group"
 	gClusterInfo = cache.NewClusterInfo()
 
 	configs.MockSchedulerConfigByData([]byte(startConf))

--- a/pkg/webservice/routes.go
+++ b/pkg/webservice/routes.go
@@ -24,36 +24,36 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
-type Route struct {
+type route struct {
 	Name        string
 	Method      string
 	Pattern     string
 	HandlerFunc http.HandlerFunc
 }
 
-type Routes []Route
+type routes []route
 
-var routes = Routes{
+var webRoutes = routes{
 	// endpoints to retrieve general scheduler info
-	Route{
+	route{
 		"Scheduler",
 		"GET",
 		"/ws/v1/queues",
 		getQueueInfo,
 	},
-	Route{
+	route{
 		"Cluster",
 		"GET",
 		"/ws/v1/clusters",
 		getClusterInfo,
 	},
-	Route{
+	route{
 		"Scheduler",
 		"GET",
 		"/ws/v1/apps",
 		getApplicationsInfo,
 	},
-	Route{
+	route{
 		"Scheduler",
 		"GET",
 		"/ws/v1/nodes",
@@ -61,7 +61,7 @@ var routes = Routes{
 	},
 
 	// endpoint to retrieve goroutines info
-	Route{
+	route{
 		"Scheduler",
 		"GET",
 		"/ws/v1/stack",
@@ -69,15 +69,23 @@ var routes = Routes{
 	},
 
 	// endpoint to retrieve server metrics
-	Route{
+	route{
 		"Scheduler",
 		"GET",
 		"/ws/v1/metrics",
 		promhttp.Handler().ServeHTTP,
 	},
 
+	// endpoint to retrieve the current conf
+	route{
+		"Scheduler",
+		"GET",
+		"/ws/v1/config",
+		getClusterConfig,
+	},
+
 	// endpoint to validate conf
-	Route{
+	route{
 		"Scheduler",
 		"POST",
 		"/ws/v1/validate-conf",
@@ -85,13 +93,13 @@ var routes = Routes{
 	},
 
 	// endpoint to retrieve historical data
-	Route{
+	route{
 		"Scheduler",
 		"GET",
 		"/ws/v1/history/apps",
 		getApplicationHistory,
 	},
-	Route{
+	route{
 		"Scheduler",
 		"GET",
 		"/ws/v1/history/containers",
@@ -102,67 +110,67 @@ var routes = Routes{
 	// this works with pprof tool. By default, pprof endpoints
 	// are only registered to http.DefaultServeMux. Here, we
 	// need to explicitly register all handlers.
-	Route{
+	route{
 		Name:        "System",
 		Method:      "GET",
 		Pattern:     "/debug/pprof/",
 		HandlerFunc: pprof.Index,
 	},
-	Route{
+	route{
 		Name:        "System",
 		Method:      "GET",
 		Pattern:     "/debug/pprof/heap",
 		HandlerFunc: pprof.Index,
 	},
-	Route{
+	route{
 		Name:        "System",
 		Method:      "GET",
 		Pattern:     "/debug/pprof/threadcreate",
 		HandlerFunc: pprof.Index,
 	},
-	Route{
+	route{
 		Name:        "System",
 		Method:      "GET",
 		Pattern:     "/debug/pprof/goroutine",
 		HandlerFunc: pprof.Index,
 	},
-	Route{
+	route{
 		Name:        "System",
 		Method:      "GET",
 		Pattern:     "/debug/pprof/allocs",
 		HandlerFunc: pprof.Index,
 	},
-	Route{
+	route{
 		Name:        "System",
 		Method:      "GET",
 		Pattern:     "/debug/pprof/block",
 		HandlerFunc: pprof.Index,
 	},
-	Route{
+	route{
 		Name:        "System",
 		Method:      "GET",
 		Pattern:     "/debug/pprof/mutex",
 		HandlerFunc: pprof.Index,
 	},
-	Route{
+	route{
 		Name:        "System",
 		Method:      "GET",
 		Pattern:     "/debug/pprof/cmdline",
 		HandlerFunc: pprof.Cmdline,
 	},
-	Route{
+	route{
 		Name:        "System",
 		Method:      "GET",
 		Pattern:     "/debug/pprof/profile",
 		HandlerFunc: pprof.Profile,
 	},
-	Route{
+	route{
 		Name:        "System",
 		Method:      "GET",
 		Pattern:     "/debug/pprof/symbol",
 		HandlerFunc: pprof.Symbol,
 	},
-	Route{
+	route{
 		Name:        "System",
 		Method:      "GET",
 		Pattern:     "/debug/pprof/trace",

--- a/pkg/webservice/webservice.go
+++ b/pkg/webservice/webservice.go
@@ -43,7 +43,7 @@ type WebService struct {
 
 func NewRouter() *mux.Router {
 	router := mux.NewRouter().StrictSlash(true)
-	for _, route := range routes {
+	for _, route := range webRoutes {
 		var handler http.Handler
 
 		handler = route.HandlerFunc

--- a/pkg/webservice/webservice.go
+++ b/pkg/webservice/webservice.go
@@ -41,24 +41,21 @@ type WebService struct {
 	lock        sync.RWMutex
 }
 
-func NewRouter() *mux.Router {
+func newRouter() *mux.Router {
 	router := mux.NewRouter().StrictSlash(true)
-	for _, route := range webRoutes {
-		var handler http.Handler
-
-		handler = route.HandlerFunc
-		handler = Logger(handler, route.Name)
+	for _, webRoute := range webRoutes {
+		handler := loggingHandler(webRoute.HandlerFunc, webRoute.Name)
 
 		router.
-			Methods(route.Method).
-			Path(route.Pattern).
-			Name(route.Name).
+			Methods(webRoute.Method).
+			Path(webRoute.Pattern).
+			Name(webRoute.Name).
 			Handler(handler)
 	}
 	return router
 }
 
-func Logger(inner http.Handler, name string) http.Handler {
+func loggingHandler(inner http.Handler, name string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
 
@@ -71,7 +68,7 @@ func Logger(inner http.Handler, name string) http.Handler {
 
 // TODO we need the port to be configurable
 func (m *WebService) StartWebApp() {
-	router := NewRouter()
+	router := newRouter()
 	m.httpServer = &http.Server{Addr: ":9080", Handler: router}
 
 	log.Logger().Info("web-app started", zap.Int("port", 9080))


### PR DESCRIPTION
Expose the running config via a web call in both yaml (default) and json
(query parameter "json" required). The end point is "/ws/v1/config".

The yaml response is a multi line marshalled yaml object.
The json response is a one line marshalled json object.
The sha512 checksum is provided as part of the response. The checksum is
not part of the marshalled data. The checksum is printed as a 32 byte
hexadecimal sha256 string.