### PR TITLE
[YUNIKORN-390] Panic in placement rule evaluation

### DIFF
--- a/pkg/scheduler/placement/fixed_rule.go
+++ b/pkg/scheduler/placement/fixed_rule.go
@@ -91,7 +91,9 @@ func (fr *fixedRule) placeApplication(app *cache.ApplicationInfo, info *cache.Pa
 			if !strings.HasPrefix(parentName, configs.RootQueue+cache.DOT) {
 				parentName = configs.RootQueue + cache.DOT + parentName
 			}
-			if info.GetQueue(parentName).IsLeafQueue() {
+			// if the parent queue exists it cannot be a leaf
+			parentQueue := info.GetQueue(parentName)
+			if parentQueue != nil && parentQueue.IsLeafQueue() {
 				return "", fmt.Errorf("parent rule returned a leaf queue: %s", parentName)
 			}
 		}

--- a/pkg/scheduler/placement/fixed_rule_test.go
+++ b/pkg/scheduler/placement/fixed_rule_test.go
@@ -156,3 +156,103 @@ partitions:
 		t.Errorf("fixed rule with parent queue should not have failed '%s', error %v", queue, err)
 	}
 }
+
+func TestFixedRuleParent(t *testing.T) {
+	// Create the structure for the test
+	data := `
+partitions:
+  - name: default
+    queues:
+      - name: testchild
+      - name: testparent
+        parent: true
+`
+	partInfo, err := CreatePartitionInfo([]byte(data))
+	assert.NilError(t, err, "Partition create failed with error")
+	user := security.UserGroup{
+		User:   "testuser",
+		Groups: []string{},
+	}
+	tags := make(map[string]string)
+	appInfo := cache.NewApplicationInfo("app1", "default", "ignored", user, tags)
+
+	// trying to place in a child using a parent, fail to create child
+	conf := configs.PlacementRule{
+		Name:   "fixed",
+		Value:  "nonexist",
+		Create: false,
+		Parent: &configs.PlacementRule{
+			Name:  "fixed",
+			Value: "testparent",
+		},
+	}
+	var fr rule
+	fr, err = newRule(conf)
+	if err != nil || fr == nil {
+		t.Errorf("fixed rule create failed with queue name, err %v", err)
+	}
+	var queue string
+	queue, err = fr.placeApplication(appInfo, partInfo)
+	if queue != "" || err != nil {
+		t.Errorf("fixed rule with create false for child should have failed and gave '%s', error %v", queue, err)
+	}
+
+	// trying to place in a child using a non creatable parent
+	conf = configs.PlacementRule{
+		Name:   "fixed",
+		Value:  "testchild",
+		Create: true,
+		Parent: &configs.PlacementRule{
+			Name:   "fixed",
+			Value:  "testparentnew",
+			Create: false,
+		},
+	}
+	fr, err = newRule(conf)
+	if err != nil || fr == nil {
+		t.Errorf("fixed rule create failed with queue name, err %v", err)
+	}
+	queue, err = fr.placeApplication(appInfo, partInfo)
+	if queue != "" || err != nil {
+		t.Errorf("fixed rule with non existing parent queue should have failed '%s', error %v", queue, err)
+	}
+
+	// trying to place in a child using a creatable parent
+	conf = configs.PlacementRule{
+		Name:   "fixed",
+		Value:  "testchild",
+		Create: true,
+		Parent: &configs.PlacementRule{
+			Name:   "fixed",
+			Value:  "testparentnew",
+			Create: true,
+		},
+	}
+	fr, err = newRule(conf)
+	if err != nil || fr == nil {
+		t.Errorf("fixed rule create failed with queue name, err %v", err)
+	}
+	queue, err = fr.placeApplication(appInfo, partInfo)
+	if queue != "root.testparentnew.testchild" || err != nil {
+		t.Errorf("fixed rule with non existing parent queue should created '%s', error %v", queue, err)
+	}
+
+	// trying to place in a child using a parent which is defined as a leaf
+	conf = configs.PlacementRule{
+		Name:   "fixed",
+		Value:  "nonexist",
+		Create: true,
+		Parent: &configs.PlacementRule{
+			Name:  "fixed",
+			Value: "testchild",
+		},
+	}
+	fr, err = newRule(conf)
+	if err != nil || fr == nil {
+		t.Errorf("fixed rule create failed with queue name, err %v", err)
+	}
+	queue, err = fr.placeApplication(appInfo, partInfo)
+	if queue != "" || err == nil {
+		t.Errorf("fixed rule with parent declared as leaf should have failed '%s', error %v", queue, err)
+	}
+}

--- a/pkg/scheduler/placement/fixed_rule_test.go
+++ b/pkg/scheduler/placement/fixed_rule_test.go
@@ -158,16 +158,7 @@ partitions:
 }
 
 func TestFixedRuleParent(t *testing.T) {
-	// Create the structure for the test
-	data := `
-partitions:
-  - name: default
-    queues:
-      - name: testchild
-      - name: testparent
-        parent: true
-`
-	partInfo, err := CreatePartitionInfo([]byte(data))
+	partInfo, err := CreatePartitionInfo([]byte(confParentChild))
 	assert.NilError(t, err, "Partition create failed with error")
 	user := security.UserGroup{
 		User:   "testuser",
@@ -233,7 +224,7 @@ partitions:
 		t.Errorf("fixed rule create failed with queue name, err %v", err)
 	}
 	queue, err = fr.placeApplication(appInfo, partInfo)
-	if queue != "root.testparentnew.testchild" || err != nil {
+	if queue != nameParentChild || err != nil {
 		t.Errorf("fixed rule with non existing parent queue should created '%s', error %v", queue, err)
 	}
 

--- a/pkg/scheduler/placement/provided_rule.go
+++ b/pkg/scheduler/placement/provided_rule.go
@@ -83,7 +83,9 @@ func (pr *providedRule) placeApplication(app *cache.ApplicationInfo, info *cache
 			if !strings.HasPrefix(parentName, configs.RootQueue+cache.DOT) {
 				parentName = configs.RootQueue + cache.DOT + parentName
 			}
-			if info.GetQueue(parentName).IsLeafQueue() {
+			// if the parent queue exists it cannot be a leaf
+			parentQueue := info.GetQueue(parentName)
+			if parentQueue != nil && parentQueue.IsLeafQueue() {
 				return "", fmt.Errorf("parent rule returned a leaf queue: %s", parentName)
 			}
 		}

--- a/pkg/scheduler/placement/provided_rule_test.go
+++ b/pkg/scheduler/placement/provided_rule_test.go
@@ -116,16 +116,7 @@ partitions:
 }
 
 func TestProvidedRuleParent(t *testing.T) {
-	// Create the structure for the test
-	data := `
-partitions:
-  - name: default
-    queues:
-      - name: testchild
-      - name: testparent
-        parent: true
-`
-	partInfo, err := CreatePartitionInfo([]byte(data))
+	partInfo, err := CreatePartitionInfo([]byte(confParentChild))
 	assert.NilError(t, err, "Partition create failed with error")
 	tags := make(map[string]string)
 	user := security.UserGroup{
@@ -191,7 +182,7 @@ partitions:
 		t.Errorf("provided rule create failed, err %v", err)
 	}
 	queue, err = pr.placeApplication(appInfo, partInfo)
-	if queue != "root.testparentnew.testchild" || err != nil {
+	if queue != nameParentChild || err != nil {
 		t.Errorf("provided rule with non existing parent queue should create '%s', error %v", queue, err)
 	}
 

--- a/pkg/scheduler/placement/tag_rule.go
+++ b/pkg/scheduler/placement/tag_rule.go
@@ -90,7 +90,9 @@ func (tr *tagRule) placeApplication(app *cache.ApplicationInfo, info *cache.Part
 			if !strings.HasPrefix(parentName, configs.RootQueue+cache.DOT) {
 				parentName = configs.RootQueue + cache.DOT + parentName
 			}
-			if info.GetQueue(parentName).IsLeafQueue() {
+			// if the parent queue exists it cannot be a leaf
+			parentQueue := info.GetQueue(parentName)
+			if parentQueue != nil && parentQueue.IsLeafQueue() {
 				return "", fmt.Errorf("parent rule returned a leaf queue: %s", parentName)
 			}
 		}

--- a/pkg/scheduler/placement/tag_rule_test.go
+++ b/pkg/scheduler/placement/tag_rule_test.go
@@ -145,9 +145,9 @@ partitions:
 	}
 }
 
-func TestTagRuleParent(t *testing.T) {
-	// Create the structure for the test
-	data := `
+// Create the structure for the parent rule tests
+// shared by a number of rule tests
+const confParentChild = `
 partitions:
   - name: default
     queues:
@@ -155,9 +155,11 @@ partitions:
       - name: testparent
         parent: true
 `
-	partInfo, err := CreatePartitionInfo([]byte(data))
+const nameParentChild = "root.testparentnew.testchild"
+
+func TestTagRuleParent(t *testing.T) {
+	partInfo, err := CreatePartitionInfo([]byte(confParentChild))
 	assert.NilError(t, err, "Partition create failed with error")
-	tags := make(map[string]string)
 	user := security.UserGroup{
 		User:   "testuser",
 		Groups: []string{},
@@ -179,7 +181,7 @@ partitions:
 		t.Errorf("tag rule create failed, err %v", err)
 	}
 
-	tags = map[string]string{"label1": "testchild", "label2": "testparent"}
+	tags := map[string]string{"label1": "testchild", "label2": "testparent"}
 	appInfo := cache.NewApplicationInfo("app1", "default", "unknown", user, tags)
 	var queue string
 	queue, err = ur.placeApplication(appInfo, partInfo)
@@ -226,7 +228,7 @@ partitions:
 		t.Errorf("tag rule create failed with queue name, err %v", err)
 	}
 	queue, err = ur.placeApplication(appInfo, partInfo)
-	if queue != "root.testparentnew.testchild" || err != nil {
+	if queue != nameParentChild || err != nil {
 		t.Errorf("user rule with non existing parent queue should create '%s', error %v", queue, err)
 	}
 

--- a/pkg/scheduler/placement/user_rule.go
+++ b/pkg/scheduler/placement/user_rule.go
@@ -74,7 +74,9 @@ func (ur *userRule) placeApplication(app *cache.ApplicationInfo, info *cache.Par
 		if !strings.HasPrefix(parentName, configs.RootQueue+cache.DOT) {
 			parentName = configs.RootQueue + cache.DOT + parentName
 		}
-		if info.GetQueue(parentName).IsLeafQueue() {
+		// if the parent queue exists it cannot be a leaf
+		parentQueue := info.GetQueue(parentName)
+		if parentQueue != nil && parentQueue.IsLeafQueue() {
 			return "", fmt.Errorf("parent rule returned a leaf queue: %s", parentName)
 		}
 	}

--- a/pkg/scheduler/placement/user_rule_test.go
+++ b/pkg/scheduler/placement/user_rule_test.go
@@ -128,16 +128,7 @@ partitions:
 }
 
 func TestUserRuleParent(t *testing.T) {
-	// Create the structure for the test
-	data := `
-partitions:
-  - name: default
-    queues:
-      - name: testchild
-      - name: testparent
-        parent: true
-`
-	partInfo, err := CreatePartitionInfo([]byte(data))
+	partInfo, err := CreatePartitionInfo([]byte(confParentChild))
 	assert.NilError(t, err, "Partition create failed with error")
 	tags := make(map[string]string)
 	user := security.UserGroup{
@@ -203,7 +194,7 @@ partitions:
 		t.Errorf("user rule create failed with queue name, err %v", err)
 	}
 	queue, err = ur.placeApplication(appInfo, partInfo)
-	if queue != "root.testparentnew.testchild" || err != nil {
+	if queue != nameParentChild || err != nil {
 		t.Errorf("user rule with non existing parent queue should create '%s', error %v", queue, err)
 	}
 

--- a/pkg/scheduler/placement/user_rule_test.go
+++ b/pkg/scheduler/placement/user_rule_test.go
@@ -126,3 +126,104 @@ partitions:
 		t.Errorf("user rule placed in to be created queue with create false '%s', err %v", queue, err)
 	}
 }
+
+func TestUserRuleParent(t *testing.T) {
+	// Create the structure for the test
+	data := `
+partitions:
+  - name: default
+    queues:
+      - name: testchild
+      - name: testparent
+        parent: true
+`
+	partInfo, err := CreatePartitionInfo([]byte(data))
+	assert.NilError(t, err, "Partition create failed with error")
+	tags := make(map[string]string)
+	user := security.UserGroup{
+		User:   "testchild",
+		Groups: []string{},
+	}
+
+	// trying to place in a child using a parent, fail to create child
+	conf := configs.PlacementRule{
+		Name:   "user",
+		Create: false,
+		Parent: &configs.PlacementRule{
+			Name:  "fixed",
+			Value: "testparent",
+		},
+	}
+	var ur rule
+	ur, err = newRule(conf)
+	if err != nil || ur == nil {
+		t.Errorf("user rule create failed, err %v", err)
+	}
+
+	appInfo := cache.NewApplicationInfo("app1", "default", "unknown", user, tags)
+	var queue string
+	queue, err = ur.placeApplication(appInfo, partInfo)
+	if queue != "" || err != nil {
+		t.Errorf("user rule placed app in incorrect queue '%s', err %v", queue, err)
+	}
+
+	// trying to place in a child using a non creatable parent
+	conf = configs.PlacementRule{
+		Name:   "user",
+		Create: true,
+		Parent: &configs.PlacementRule{
+			Name:   "fixed",
+			Value:  "testother",
+			Create: false,
+		},
+	}
+	ur, err = newRule(conf)
+	if err != nil || ur == nil {
+		t.Errorf("user rule create failed, err %v", err)
+	}
+
+	appInfo = cache.NewApplicationInfo("app1", "default", "unknown", user, tags)
+	queue, err = ur.placeApplication(appInfo, partInfo)
+	if queue != "" || err != nil {
+		t.Errorf("user rule placed app in incorrect queue '%s', err %v", queue, err)
+	}
+
+	// trying to place in a child using a creatable parent
+	conf = configs.PlacementRule{
+		Name:   "user",
+		Create: true,
+		Parent: &configs.PlacementRule{
+			Name:   "fixed",
+			Value:  "testparentnew",
+			Create: true,
+		},
+	}
+	ur, err = newRule(conf)
+	if err != nil || ur == nil {
+		t.Errorf("user rule create failed with queue name, err %v", err)
+	}
+	queue, err = ur.placeApplication(appInfo, partInfo)
+	if queue != "root.testparentnew.testchild" || err != nil {
+		t.Errorf("user rule with non existing parent queue should create '%s', error %v", queue, err)
+	}
+
+	// trying to place in a child using a parent which is defined as a leaf
+	conf = configs.PlacementRule{
+		Name:   "user",
+		Create: true,
+		Parent: &configs.PlacementRule{
+			Name:  "fixed",
+			Value: "testchild",
+		},
+	}
+	ur, err = newRule(conf)
+	if err != nil || ur == nil {
+		t.Errorf("user rule create failed, err %v", err)
+	}
+
+	appInfo = cache.NewApplicationInfo("app1", "default", "unknown", user, tags)
+	queue, err = ur.placeApplication(appInfo, partInfo)
+	if queue != "" || err == nil {
+		t.Errorf("user rule placed app in incorrect queue '%s', err %v", queue, err)
+	}
+}


### PR DESCRIPTION
Placement rules can specify an arbitrary parent rule and a create flag for
the parent rule. If the parent rule is configured with the create flag set
to "true" and returns a non-existing queue the scheduler panics.

The fact that the parent queue does not exist means it cannot be a leaf
queue and the isLeafQueue() check should be skipped.
Adding tests to cover the parent rule returns to all rules.