### PR TITLE
[YUNIKORN-397] Makefile use go version from go.mod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,11 +15,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Check if this is at least GO tools used is at least the version of go specified in
+# the go.mod file. The version in go.mod should be in sync with other repos.
+GO_VERSION := $(shell go version | awk '{print substr($$3, 3, 10)}')
+MOD_VERSION := $(shell awk '/^go/ {print $$2}' go.mod)
 
-# Check if this is at least GO 1.11 for Go Modules
-GO_VERSION := $(shell go version | awk '$$3 ~ /go1.(10|0-9])/ {print $$3}')
-ifdef GO_VERSION
-$(error Build requires go 1.11 or later)
+GM := $(word 1,$(subst ., ,$(GO_VERSION)))
+MM := $(word 1,$(subst ., ,$(MOD_VERSION)))
+FAIL := $(shell if [[ $(GM) -lt $(MM) ]]; then echo MAJOR; fi)
+ifdef FAIL
+$(error Build should be run with at least go $(MOD_VERSION) or later, found $(GO_VERSION))
+endif
+GM := $(word 2,$(subst ., ,$(GO_VERSION)))
+MM := $(word 2,$(subst ., ,$(MOD_VERSION)))
+FAIL := $(shell if [[ $(GM) -lt $(MM) ]]; then echo MINOR; fi)
+ifdef FAIL
+$(error Build should be run with at least go $(MOD_VERSION) or later, found $(GO_VERSION))
 endif
 
 # Make sure we are in the same directory as the Makefile

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Check if this is at least GO tools used is at least the version of go specified in
+# Check if this GO tools version used is at least the version of go specified in
 # the go.mod file. The version in go.mod should be in sync with other repos.
 GO_VERSION := $(shell go version | awk '{print substr($$3, 3, 10)}')
 MOD_VERSION := $(shell awk '/^go/ {print $$2}' go.mod)


### PR DESCRIPTION
Instead of hard coding a go version in the Makefile use the version
from the go.mod file. The build will fail if the installed tools version
is lower than the version from the go.mod file.