### PR TITLE
[YUNIKORN-404] Config update breaks when there is upper case queue names

### DIFF
--- a/pkg/cache/partition_info.go
+++ b/pkg/cache/partition_info.go
@@ -803,7 +803,7 @@ func (pi *PartitionInfo) updateQueues(config []configs.QueueConfig, parent *Queu
 		if err != nil {
 			return err
 		}
-		visited[queueConfig.Name] = true
+		visited[queue.Name] = true
 	}
 	// remove all children that were not visited
 	for childName, childQueue := range parent.children {

--- a/pkg/cache/partition_info_test.go
+++ b/pkg/cache/partition_info_test.go
@@ -26,6 +26,7 @@ import (
 	"gotest.tools/assert"
 
 	"github.com/apache/incubator-yunikorn-core/pkg/common/commonevents"
+	"github.com/apache/incubator-yunikorn-core/pkg/common/configs"
 	"github.com/apache/incubator-yunikorn-core/pkg/common/resources"
 	"github.com/apache/incubator-yunikorn-scheduler-interface/lib/go/si"
 )
@@ -833,4 +834,117 @@ partitions:
 	m = partition.CalculateNodesResourceUsage()
 	assert.Equal(t, len(m), 2)
 	assert.Assert(t, reflect.DeepEqual(m["memory"], []int{1, 1, 0, 0, 0, 0, 0, 0, 1, 0}))
+}
+
+func TestUpdatePartitionWithUpperCaseQueueNames(t *testing.T) {
+	data := `
+partitions:
+  - name: default
+    queues:
+      - name: root
+        queues:
+          - name: test
+            resources:
+              guaranteed:
+                memory: 200
+                vcore: 200
+              max:
+                memory: 200
+                vcore: 200
+`
+
+	partition, err := CreatePartitionInfo([]byte(data))
+	assert.NilError(t, err)
+
+	data = `
+partitions:
+  - name: default
+    queues:
+    - name: root
+      submitacl: '*'
+      queues:
+      - name: a
+        queues:
+        - name: b
+          queues:
+          - name: c
+      - name: UPPER-CASE-QUEUE
+        queues:
+        - name: UPPER-CASE-CHILD
+          resources:
+            guaranteed:
+              memory: 80000
+              vcore: 8000
+`
+	updatedConf, err := configs.LoadSchedulerConfigFromByteArray([]byte(data))
+	assert.NilError(t, err)
+
+	err = partition.updatePartitionDetails(updatedConf.Partitions[0])
+	assert.NilError(t, err)
+
+	// post update, expected result:
+	// - root.someQueue is removed
+	// - root.a.b.c is added
+	// - root.upper-case-queue.upper-case-child is added
+	queueInfo := partition.getQueue("root.test")
+	assert.Assert(t, queueInfo != nil)
+	assert.Equal(t, queueInfo.IsDraining(), true)
+
+	queueInfo = partition.getQueue("root.a.b.c")
+	assert.Assert(t, queueInfo != nil)
+	assert.Equal(t, queueInfo.IsDraining(), false)
+
+	queueInfo = partition.getQueue("root.upper-case-queue")
+	assert.NilError(t, err)
+	assert.Assert(t, queueInfo != nil)
+	assert.Equal(t, queueInfo.IsDraining(), false)
+
+	queueInfo = partition.getQueue("root.upper-case-queue.upper-case-child")
+	assert.Assert(t, queueInfo != nil)
+	assert.Equal(t, queueInfo.IsDraining(), false)
+
+	data = `
+partitions:
+  - name: default
+    queues:
+    - name: root
+      submitacl: '*'
+      queues:
+      - name: a
+        queues:
+        - name: b
+          queues:
+          - name: c
+      - name: added-queue
+        queues:
+        - name: child1
+          queues:
+          - name: child11
+`
+	updatedConf, err = configs.LoadSchedulerConfigFromByteArray([]byte(data))
+	assert.NilError(t, err)
+
+	err = partition.updatePartitionDetails(updatedConf.Partitions[0])
+	assert.NilError(t, err)
+
+	// post update, expected result:
+	// - root.a.b.c retains
+	// - root.added-queue.child1.child11 is added
+	// - root.upper-case-queue.upper-case-child is marked for deletion
+	queueInfo = partition.getQueue("root.a.b.c")
+	assert.Assert(t, queueInfo != nil)
+	assert.Equal(t, queueInfo.IsDraining(), false)
+
+	queueInfo = partition.getQueue("root.added-queue.child1.child11")
+	assert.Assert(t, queueInfo != nil)
+	assert.Equal(t, queueInfo.IsDraining(), false)
+
+	queueInfo = partition.getQueue("root.upper-case-queue")
+	assert.NilError(t, err)
+	assert.Assert(t, queueInfo != nil)
+	assert.Equal(t, queueInfo.IsDraining(), true)
+
+	queueInfo = partition.getQueue("root.upper-case-queue.upper-case-child")
+	assert.Assert(t, queueInfo != nil)
+	assert.Equal(t, queueInfo.IsDraining(), true)
 }


### PR DESCRIPTION
This is actually due to the queue was named as upper case "X", internally we are converting all upper case letters in the queue to lower cases, see code here. When the scheduler tries to update the queues, it got confused because it thinks it visited "root.x", but not "root.X". So it marks the queue "root.X" for removal.