### PR TITLE
[YUNIKORN-227] Include ask tags exposed via REST API

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -87,6 +87,7 @@ func newSingleAllocationProposal(alloc *schedulingAllocation) *cacheevent.Alloca
 				QueueName:         alloc.schedulingAsk.QueueName,
 				AllocatedResource: alloc.schedulingAsk.AllocatedResource,
 				AllocationKey:     alloc.schedulingAsk.AskProto.AllocationKey,
+				Tags:              alloc.schedulingAsk.AskProto.Tags,
 				Priority:          alloc.schedulingAsk.AskProto.Priority,
 				PartitionName:     alloc.schedulingAsk.PartitionName,
 			},


### PR DESCRIPTION
Tested against `docker-desktop`. Response of /ws/v1/apps:
- Before the patch:
```json
[
    {
        "applicationID": "application-sleep-0001",
        "usedResource": "[memory:500 vcore:100]",
        "partition": "[mycluster]default",
        "queueName": "root.default",
        "submissionTime": 1600692185822369000,
        "allocations": [
            {
                "allocationKey": "849185df-7e88-4478-bc86-dd9b4cea83e4",
                "allocationTags": nil,
                "uuid": "66a1013b-a278-4b6e-bd70-4ccb3d13eacb",
                "resource": "[memory:500 vcore:100]",
                "priority": "<nil>",
                "queueName": "root.default",
                "nodeId": "docker-desktop",
                "applicationId": "application-sleep-0001",
                "partition": "default"
            }
        ],
        "applicationState": "Starting"
    },
    ...
```
- After the patch:
```json
[
    {
        "applicationID": "application-sleep-0001",
        "usedResource": "[memory:500 vcore:100]",
        "partition": "[mycluster]default",
        "queueName": "root.default",
        "submissionTime": 1600692185822369000,
        "allocations": [
            {
                "allocationKey": "849185df-7e88-4478-bc86-dd9b4cea83e4",
                "allocationTags": {
                    "kubernetes.io/label/app": "sleep",
                    "kubernetes.io/label/applicationId": "application-sleep-0001",
                    "kubernetes.io/label/queue": "root.sandbox",
                    "kubernetes.io/meta/namespace": "default",
                    "kubernetes.io/meta/podName": "task0"
                },
                "uuid": "66a1013b-a278-4b6e-bd70-4ccb3d13eacb",
                "resource": "[memory:500 vcore:100]",
                "priority": "<nil>",
                "queueName": "root.default",
                "nodeId": "docker-desktop",
                "applicationId": "application-sleep-0001",
                "partition": "default"
            }
        ],
        "applicationState": "Starting"
    },
    ...
```