### PR TITLE
[YUNIKORN-429] Set default logging level to INFO

### DIFF
--- a/pkg/cache/queue_info.go
+++ b/pkg/cache/queue_info.go
@@ -88,7 +88,7 @@ func NewManagedQueue(conf configs.QueueConfig, parent *QueueInfo) (*QueueInfo, e
 		}
 	}
 
-	log.Logger().Debug("queue added",
+	log.Logger().Info("queue added",
 		zap.String("queueName", qi.Name),
 		zap.String("queuePath", qi.GetQueuePath()))
 	return qi, nil

--- a/pkg/common/configs/configvalidator.go
+++ b/pkg/common/configs/configvalidator.go
@@ -377,8 +377,6 @@ func Validate(newConfig *SchedulerConfig) error {
 			partition.Name = DefaultPartition
 		}
 		// check the queue structure
-		log.Logger().Info("checking partition",
-			zap.String("partitionName", partition.Name))
 		err := checkQueuesStructure(&partition)
 		if err != nil {
 			return err

--- a/pkg/common/configs/configvalidator.go
+++ b/pkg/common/configs/configvalidator.go
@@ -377,7 +377,7 @@ func Validate(newConfig *SchedulerConfig) error {
 			partition.Name = DefaultPartition
 		}
 		// check the queue structure
-		log.Logger().Debug("checking partition",
+		log.Logger().Info("checking partition",
 			zap.String("partitionName", partition.Name))
 		err := checkQueuesStructure(&partition)
 		if err != nil {

--- a/pkg/entrypoint/entrypoint.go
+++ b/pkg/entrypoint/entrypoint.go
@@ -65,6 +65,7 @@ func startAllServicesWithParameters(opts StartupOptions) *ServiceContext {
 	var eventCache *events.EventCache
 	var eventPublisher events.EventPublisher
 	if opts.eventCacheEnabled {
+		log.Logger().Info("creating event cache")
 		events.CreateAndSetEventCache()
 		eventCache = events.GetEventCache()
 		eventPublisher = events.CreateShimPublisher(eventCache.Store)
@@ -100,6 +101,7 @@ func startAllServicesWithParameters(opts StartupOptions) *ServiceContext {
 
 	var imHistory *history.InternalMetricsHistory
 	if opts.metricsHistorySize != 0 {
+		log.Logger().Info("creating InternalMetricsHistory")
 		imHistory = history.NewInternalMetricsHistory(opts.metricsHistorySize)
 		metricsCollector := metrics.NewInternalMetricsCollector(imHistory)
 		metricsCollector.StartService()

--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -33,23 +33,23 @@ func RegisterSchedulerPlugin(plugin interface{}) {
 	defer plugins.Unlock()
 
 	if t, ok := plugin.(PredicatesPlugin); ok {
-		log.Logger().Debug("register scheduler plugin: PredicatesPlugin")
+		log.Logger().Info("register scheduler plugin: PredicatesPlugin")
 		plugins.predicatesPlugin = t
 	}
 	if t, ok := plugin.(ReconcilePlugin); ok {
-		log.Logger().Debug("register scheduler plugin: ReconcilePlugin")
+		log.Logger().Info("register scheduler plugin: ReconcilePlugin")
 		plugins.reconcilePlugin = t
 	}
 	if t, ok := plugin.(EventPlugin); ok {
-		log.Logger().Debug("register scheduler plugin: EventPlugin")
+		log.Logger().Info("register scheduler plugin: EventPlugin")
 		plugins.eventPlugin = t
 	}
 	if t, ok := plugin.(ContainerSchedulingStateUpdater); ok {
-		log.Logger().Debug("register scheduler plugin: ContainerSchedulingStateUpdater")
+		log.Logger().Info("register scheduler plugin: ContainerSchedulingStateUpdater")
 		plugins.schedulingStateUpdater = t
 	}
 	if t, ok := plugin.(ConfigurationPlugin); ok {
-		log.Logger().Debug("register scheduler plugin: ConfigMapPlugin")
+		log.Logger().Info("register scheduler plugin: ConfigMapPlugin")
 		plugins.configPlugin = t
 	}
 }

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -131,6 +131,8 @@ func (s *Scheduler) inspectOutstandingRequests() {
 	for _, psc := range s.clusterSchedulingContext.getPartitionMapClone() {
 		requests := psc.calculateOutstandingRequests()
 		if len(requests) > 0 {
+			log.Logger().Info("outstanding requests",
+				zap.Int("size", len(requests)))
 			for _, ask := range requests {
 				log.Logger().Debug("outstanding request",
 					zap.String("appID", ask.AskProto.ApplicationID),

--- a/pkg/scheduler/scheduling_application.go
+++ b/pkg/scheduler/scheduling_application.go
@@ -322,7 +322,8 @@ func (sa *SchedulingApplication) reserve(node *SchedulingNode, ask *schedulingAl
 		return err
 	}
 	sa.reservations[nodeReservation.getKey()] = nodeReservation
-	// reservation added successfully
+	log.Logger().Info("reservation added successfully", zap.String("node", node.NodeID),
+		zap.String("app", ask.ApplicationID), zap.String("ask", ask.AskProto.AllocationKey))
 	return nil
 }
 
@@ -363,6 +364,7 @@ func (sa *SchedulingApplication) unReserveInternal(node *SchedulingNode, ask *sc
 				zap.String("ask", ask.AskProto.AllocationKey))
 		}
 		delete(sa.reservations, resKey)
+		// TODO: unreserve successful
 		return 1, nil
 	}
 	// reservation was not found

--- a/pkg/scheduler/scheduling_application.go
+++ b/pkg/scheduler/scheduling_application.go
@@ -364,7 +364,8 @@ func (sa *SchedulingApplication) unReserveInternal(node *SchedulingNode, ask *sc
 				zap.String("ask", ask.AskProto.AllocationKey))
 		}
 		delete(sa.reservations, resKey)
-		// TODO: unreserve successful
+		log.Logger().Info("reservation removed successfully", zap.String("node", node.NodeID),
+			zap.String("app", ask.ApplicationID), zap.String("ask", ask.AskProto.AllocationKey))
 		return 1, nil
 	}
 	// reservation was not found

--- a/pkg/scheduler/scheduling_partition.go
+++ b/pkg/scheduler/scheduling_partition.go
@@ -247,12 +247,12 @@ func (psc *partitionSchedulingContext) createSchedulingQueue(name string, user s
 	// Check the ACL before we really create
 	// The existing parent scheduling queue is the lowest we need to look at
 	if !parent.checkSubmitAccess(user) {
-		log.Logger().Debug("Submit access denied by scheduler on queue",
+		log.Logger().Info("Submit access denied by scheduler on queue",
 			zap.String("deniedQueueName", schedQueue),
 			zap.String("requestedQueue", name))
 		return
 	}
-	log.Logger().Debug("Creating scheduling queue(s)",
+	log.Logger().Info("Creating scheduling queue(s)",
 		zap.String("parent", schedQueue),
 		zap.String("child", cacheQueue),
 		zap.String("fullPath", name))


### PR DESCRIPTION
Rationalized a few log items in the core:
- increased log level from DEBUG to INFO when:
  - adding a new managed queue 
  - validating configs (once per partition). More granular logs are kept in DEBUG level
  - registering scheduler plugins
- added a few extra lines in `entrypoint.go` to display what services have been started with YuniKorn

When the log levels are increased from DEBUG to INFO we will get rid of the following entries:
1. All the DEBUG level FTM log entries, like this:
```
2020-10-01T14:40:12.912+0200	DEBUG	scheduler/scheduler.go:231	enqueued event	{"eventType": "*schedulerevent.SchedulerUpdatePartitionsConfigEvent", "eventError": "json: unsupported type: chan *commonevents.Result", "currentQueueSize": 0}
```
I think we're fine to remove all these.

2. Outstanding request inspection:
```
2020-10-01T14:40:13.888+0200	DEBUG	scheduler/scheduler.go:129	inspect outstanding requests
2020-10-01T14:42:24.923+0200	DEBUG	scheduler/scheduler.go:135	outstanding request	{"appID": "batch-sleep-job-1", "allocationKey": "3574688c-009b-452b-bdf8-2b66d499e02f"}
```
I think both of them can be kept in debug level, because in case of a busy cluster than can be lots of these logs entries, and by default this log appears in every second. I added an aggregated variation about the outstanding request in `inspectOutstandingRequests()` in INFO level. This gives the information about the size of the pending requests, but does not flood the logs.

3. Queue cleaner
```
2020-10-01T14:41:02.925+0200	DEBUG	scheduler/partition_manager.go:62	time consumed for queue cleaner	{"duration": "24.489µs"}
```
I think this can be kept in debug level as well, it is not an essential information.

4. Metrics collection
```
2020-10-01T14:41:12.887+0200	DEBUG	metrics/metrics_collector.go:58	Adding current status to historical partition data
```
This log appears in every minute. I think if we display in `entrypoint.go` that YuniKorn have started the metrics collection there's no need to display this in every minute.