### PR TITLE
[YUNIKORN-445] Panic in Resource.String()

### DIFF
--- a/pkg/common/resources/resources.go
+++ b/pkg/common/resources/resources.go
@@ -93,6 +93,9 @@ func NewResourceFromConf(configMap map[string]string) (*Resource, error) {
 }
 
 func (r *Resource) String() string {
+	if r == nil {
+		return "nil resource"
+	}
 	return fmt.Sprintf("%v", r.Resources)
 }
 

--- a/pkg/common/resources/resources_test.go
+++ b/pkg/common/resources/resources_test.go
@@ -1371,3 +1371,15 @@ func TestNewResourceFromString(t *testing.T) {
 		}
 	}
 }
+
+func TestToString(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatal("String panic on nil resource")
+		}
+	}()
+	var res *Resource
+	// ignore nil check from IDE we really want to do this
+	resString := res.String()
+	assert.Equal(t, resString, "nil resource", "Unexpected string returned for nil resource")
+}


### PR DESCRIPTION
The String method of Resource is not nil safe which causes a panic to be
logged instead of a proper message.