### PR TITLE
[YUNIKORN-285] change lint sha detection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ go:
   - "1.15"
 
 git:
-  depth: 1
+  depth: 2
 
 env:
   - GO111MODULE=on

--- a/Makefile
+++ b/Makefile
@@ -54,11 +54,6 @@ all:
 .PHONY: lint
 # Run lint against the previous commit for PR and branch build
 # In dev setup look at all changes on top of master
-REV := "HEAD^"
-DETACHED := $(findstring "fatal:", $(shell git symbolic-ref HEAD))
-ifndef DETACHED
-REV := "origin/HEAD"
-endif
 lint:
 	@echo "running golangci-lint"
 	@lintBin=$$(go env GOPATH)/bin/golangci-lint ; \
@@ -69,8 +64,9 @@ lint:
 			exit 1; \
 		fi \
 	fi ; \
-	headSHA=$$(git rev-parse --short=12 $(REV)) ; \
-	echo "checking against commit sha $${headSHA}" ; \
+        git symbolic-ref -q HEAD && REV="origin/HEAD" || REV="HEAD^" ; \
+        headSHA=$$(git rev-parse --short=12 $${REV}) ; \
+        echo "checking against commit sha $${headSHA}" ; \
 	$${lintBin} run --new-from-rev=$${headSHA}
 
 .PHONY: license-check

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,13 @@ all:
 	$(MAKE) -C $(dir $(BASE_DIR)) build
 
 .PHONY: lint
+# Run lint against the previous commit for PR and branch build
+# In dev setup look at all changes on top of master
+REV := "HEAD^"
+DETACHED := $(findstring "fatal:", $(shell git symbolic-ref HEAD))
+ifndef DETACHED
+REV := "origin/HEAD"
+endif
 lint:
 	@echo "running golangci-lint"
 	@lintBin=$$(go env GOPATH)/bin/golangci-lint ; \
@@ -62,7 +69,8 @@ lint:
 			exit 1; \
 		fi \
 	fi ; \
-	headSHA=$$(git rev-parse --short=12 origin/HEAD) ; \
+	headSHA=$$(git rev-parse --short=12 $(REV)) ; \
+	echo "checking against commit sha $${headSHA}" ; \
 	$${lintBin} run --new-from-rev=$${headSHA}
 
 .PHONY: license-check


### PR DESCRIPTION
In a branch or PR the CI build has a limited history and often a
detached head. The lint sha detection does not work in all cases.
Adding detached head detection and changing the default reference for
the sha to HEAD^
Bring travis checkout depth inline with the shim.