### PR TITLE
[YUNIKORN-480] root queue max resource update

### DIFF
--- a/pkg/scheduler/objects/utilities_test.go
+++ b/pkg/scheduler/objects/utilities_test.go
@@ -59,7 +59,23 @@ func createManagedQueueWithProps(parentSQ *Queue, name string, parent bool, maxR
 			Max: maxRes,
 		}
 	}
-	return NewConfiguredQueue(queueConfig, parentSQ)
+	queue, err := NewConfiguredQueue(queueConfig, parentSQ)
+	if err != nil {
+		return nil, err
+	}
+	// root queue can not set the max via the config
+	if parentSQ == nil {
+		var max *resources.Resource
+		max, err = resources.NewResourceFromConf(maxRes)
+		if err != nil {
+			return nil, err
+		}
+		// only set if we have some limit
+		if len(max.Resources) > 0 && !resources.IsZero(max) {
+			queue.SetMaxResource(max)
+		}
+	}
+	return queue, nil
 }
 
 // wrapper around the create call using the one syntax for all queue types

--- a/pkg/scheduler/partition_test.go
+++ b/pkg/scheduler/partition_test.go
@@ -1071,6 +1071,7 @@ func TestUpdateRootQueue(t *testing.T) {
 	}
 
 	err = partition.updatePartitionDetails(conf)
+	assert.NilError(t, err, "partition update failed")
 	// resources should not have changed
 	assert.Assert(t, resources.Equals(res, partition.totalPartitionResource), "partition resource not set as expected")
 	assert.Assert(t, resources.Equals(res, partition.root.GetMaxResource()), "root max resource not set as expected")

--- a/pkg/scheduler/partition_test.go
+++ b/pkg/scheduler/partition_test.go
@@ -1042,3 +1042,39 @@ func TestScheduleRemoveReservedAsk(t *testing.T) {
 	assert.Equal(t, len(partition.reservedApps), 1, "partition should still have reserved app")
 	assert.Equal(t, len(app.GetReservations()), 1, "application reservations should be kept at 1")
 }
+
+// update the config with nodes registered and make sure that the root max and guaranteed are not changed
+func TestUpdateRootQueue(t *testing.T) {
+	partition := createQueuesNodes(t)
+	if partition == nil {
+		t.Fatal("partition create failed")
+	}
+	res, err := resources.NewResourceFromConf(map[string]string{"first": "20"})
+	assert.NilError(t, err, "resource creation failed")
+	assert.Assert(t, resources.Equals(res, partition.totalPartitionResource), "partition resource not set as expected")
+	assert.Assert(t, resources.Equals(res, partition.root.GetMaxResource()), "root max resource not set as expected")
+
+	conf := configs.PartitionConfig{
+		Name: "test",
+		Queues: []configs.QueueConfig{
+			{
+				Name:      "root",
+				Parent:    true,
+				SubmitACL: "*",
+				Queues:    nil,
+			},
+		},
+		PlacementRules: nil,
+		Limits:         nil,
+		Preemption:     configs.PartitionPreemptionConfig{},
+		NodeSortPolicy: configs.NodeSortingPolicy{},
+	}
+
+	err = partition.updatePartitionDetails(conf)
+	// resources should not have changed
+	assert.Assert(t, resources.Equals(res, partition.totalPartitionResource), "partition resource not set as expected")
+	assert.Assert(t, resources.Equals(res, partition.root.GetMaxResource()), "root max resource not set as expected")
+	// make sure the update went through
+	assert.Equal(t, partition.GetQueue("root.leaf").CurrentState(), objects.Draining.String(), "leaf queue should have been marked for removal")
+	assert.Equal(t, partition.GetQueue("root.parent").CurrentState(), objects.Draining.String(), "parent queue should have been marked for removal")
+}


### PR DESCRIPTION
When updating the configuration the root queue max resources should not
be set to the value specified in the config. The root queue represents
the total resources available on the cluster and is updated when nodes
are added removed.
Existing tests in the queue already cover this as part of the test queue
creation. A new test is added to the partition tests to cover the config
update.