### PR TITLE
[YUNIKORN-481] deadlock when removing allocation ask

### DIFF
--- a/pkg/scheduler/objects/allocation.go
+++ b/pkg/scheduler/objects/allocation.go
@@ -68,7 +68,7 @@ func NewAllocation(uuid, nodeID string, ask *AllocationAsk) *Allocation {
 		UUID:              uuid,
 		Tags:              ask.Tags,
 		Priority:          ask.priority,
-		AllocatedResource: ask.AllocatedResource,
+		AllocatedResource: ask.AllocatedResource.Clone(),
 		Result:            Allocated,
 	}
 }
@@ -80,7 +80,7 @@ func newReservedAllocation(result allocationResult, nodeID string, ask *Allocati
 		ApplicationID:     ask.ApplicationID,
 		NodeID:            nodeID,
 		PartitionName:     common.GetPartitionNameWithoutClusterID(ask.PartitionName),
-		AllocatedResource: ask.AllocatedResource,
+		AllocatedResource: ask.AllocatedResource.Clone(),
 		Result:            result,
 	}
 }

--- a/pkg/scheduler/objects/node.go
+++ b/pkg/scheduler/objects/node.go
@@ -330,6 +330,11 @@ func (sn *Node) preConditions(allocID string, allocate bool) bool {
 			NodeID:        sn.NodeID,
 			Allocate:      allocate,
 		}); err != nil {
+			log.Logger().Debug("running predicates failed",
+				zap.String("allocationKey", allocID),
+				zap.String("nodeID", sn.NodeID),
+				zap.Bool("allocateFlag", allocate),
+				zap.Error(err))
 			// running predicates failed
 			return false
 		}

--- a/pkg/scheduler/partition_test.go
+++ b/pkg/scheduler/partition_test.go
@@ -1032,7 +1032,7 @@ func TestScheduleRemoveReservedAsk(t *testing.T) {
 	}
 	released := app.RemoveAllocationAsk(removeAskID)
 	assert.Equal(t, released, 1, "expected one reservations to be released")
-	partition.unReserveCount(appID1, released)
+	partition.unReserveCountInternal(appID1, released)
 	assert.Equal(t, len(partition.reservedApps), 1, "partition should still have reserved app")
 	assert.Equal(t, len(app.GetReservations()), 1, "application reservations should be 1")
 


### PR DESCRIPTION
When removing an allocationAsk the partition was locked before the
application scheduling itself does it the other way around which can
cause a deadlock if the ask is removed while the application is
scheduled.
Possible deadlock in the node usage calculation removed.

Removal of an allocation contains a possible deadlock which has not been
handled as YUNIKORN-461 is open for changing that behaviour already.

E2E tests run as part of the k8shim cover the testing.