### PR TITLE
YUNIKORN-466: Node capacity update does not update root queue or partition

### DIFF
--- a/pkg/scheduler/context.go
+++ b/pkg/scheduler/context.go
@@ -533,7 +533,7 @@ func (cc *ClusterContext) updateNodes(request *si.UpdateRequest) {
 			switch update.Action {
 			case si.UpdateNodeInfo_UPDATE:
 				if sr := update.SchedulableResource; sr != nil {
-					partition.updateNode(node, resources.NewResourceFromProto(sr))
+					partition.updateNode(node.SetCapacity(resources.NewResourceFromProto(sr)))
 				}
 				if or := update.OccupiedResource; or != nil {
 					newOccupied := resources.NewResourceFromProto(or)

--- a/pkg/scheduler/context.go
+++ b/pkg/scheduler/context.go
@@ -533,8 +533,7 @@ func (cc *ClusterContext) updateNodes(request *si.UpdateRequest) {
 			switch update.Action {
 			case si.UpdateNodeInfo_UPDATE:
 				if sr := update.SchedulableResource; sr != nil {
-					newCapacity := resources.NewResourceFromProto(sr)
-					node.SetCapacity(newCapacity)
+					partition.updateNode(node, resources.NewResourceFromProto(sr))
 				}
 				if or := update.OccupiedResource; or != nil {
 					newOccupied := resources.NewResourceFromProto(or)

--- a/pkg/scheduler/objects/node.go
+++ b/pkg/scheduler/objects/node.go
@@ -127,15 +127,18 @@ func (sn *Node) GetCapacity() *resources.Resource {
 	return sn.totalResource.Clone()
 }
 
-func (sn *Node) SetCapacity(newCapacity *resources.Resource) {
+func (sn *Node) SetCapacity(newCapacity *resources.Resource) *resources.Resource {
 	sn.Lock()
 	defer sn.Unlock()
+	var delta *resources.Resource = nil
 	if resources.Equals(sn.totalResource, newCapacity) {
 		log.Logger().Debug("skip updating capacity, not changed")
-		return
+		return delta
 	}
+	delta = resources.Sub(newCapacity, sn.totalResource)
 	sn.totalResource = newCapacity
 	sn.refreshAvailableResource()
+	return delta
 }
 
 func (sn *Node) GetOccupiedResource() *resources.Resource {

--- a/pkg/scheduler/objects/node.go
+++ b/pkg/scheduler/objects/node.go
@@ -130,12 +130,11 @@ func (sn *Node) GetCapacity() *resources.Resource {
 func (sn *Node) SetCapacity(newCapacity *resources.Resource) *resources.Resource {
 	sn.Lock()
 	defer sn.Unlock()
-	var delta *resources.Resource = nil
 	if resources.Equals(sn.totalResource, newCapacity) {
 		log.Logger().Debug("skip updating capacity, not changed")
-		return delta
+		return nil
 	}
-	delta = resources.Sub(newCapacity, sn.totalResource)
+	delta := resources.Sub(newCapacity, sn.totalResource)
 	sn.totalResource = newCapacity
 	sn.refreshAvailableResource()
 	return delta

--- a/pkg/scheduler/partition.go
+++ b/pkg/scheduler/partition.go
@@ -587,13 +587,13 @@ func (pc *PartitionContext) removeNode(nodeID string) []*objects.Allocation {
 }
 
 // Update a node
-func (pc *PartitionContext) updateNode(node *objects.Node, newCapacity *resources.Resource) {
+func (pc *PartitionContext) updateNode(delta *resources.Resource) {
 	pc.Lock()
 	defer pc.Unlock()
-	pc.totalPartitionResource.AddTo(newCapacity)
-	pc.totalPartitionResource.SubFrom(node.GetCapacity())
-	pc.root.SetMaxResource(pc.totalPartitionResource)
-	node.SetCapacity(newCapacity)
+	if delta != nil {
+		pc.totalPartitionResource.AddTo(delta)
+		pc.root.SetMaxResource(pc.totalPartitionResource)
+	}
 }
 
 // Remove a node from the partition. It returns all removed allocations.

--- a/pkg/scheduler/partition.go
+++ b/pkg/scheduler/partition.go
@@ -586,6 +586,16 @@ func (pc *PartitionContext) removeNode(nodeID string) []*objects.Allocation {
 	return pc.removeNodeInternal(nodeID)
 }
 
+// Update a node
+func (pc *PartitionContext) updateNode(node *objects.Node, newCapacity *resources.Resource) {
+	pc.Lock()
+	defer pc.Unlock()
+	pc.totalPartitionResource.AddTo(newCapacity)
+	pc.totalPartitionResource.SubFrom(node.GetCapacity())
+	pc.root.SetMaxResource(pc.totalPartitionResource)
+	node.SetCapacity(newCapacity)
+}
+
 // Remove a node from the partition. It returns all removed allocations.
 // Unlocked version must be called holding the partition lock.
 func (pc *PartitionContext) removeNodeInternal(nodeID string) []*objects.Allocation {

--- a/pkg/scheduler/partition_test.go
+++ b/pkg/scheduler/partition_test.go
@@ -1095,7 +1095,7 @@ func TestUpdateNode(t *testing.T) {
 		t.Errorf("Expected partition resource %s, doesn't match with actual partition resource %s", newRes, partition.GetTotalPartitionResource())
 	}
 
-	//delta resource for a node with mem as 450 and vcores as 40 (both mem and vcores has increeased)
+	// delta resource for a node with mem as 450 and vcores as 40 (both mem and vcores has increeased)
 	delta, err := resources.NewResourceFromConf(map[string]string{"memory": "50", "vcore": "10"})
 	assert.NilError(t, err, "failed to create resource")
 	partition.updateNode(delta)
@@ -1107,7 +1107,7 @@ func TestUpdateNode(t *testing.T) {
 		t.Errorf("Expected partition resource %s, doesn't match with actual partition resource %s", expectedRes, partition.GetTotalPartitionResource())
 	}
 
-	///delta resource for a node with mem as 400 and vcores as 30 (both mem and vcores has decreased)
+	// delta resource for a node with mem as 400 and vcores as 30 (both mem and vcores has decreased)
 	delta, err = resources.NewResourceFromConf(map[string]string{"memory": "-50", "vcore": "-10"})
 	assert.NilError(t, err, "failed to create resource")
 	partition.updateNode(delta)
@@ -1119,7 +1119,7 @@ func TestUpdateNode(t *testing.T) {
 		t.Errorf("Expected partition resource %s, doesn't match with actual partition resource %s", expectedRes, partition.GetTotalPartitionResource())
 	}
 
-	//delta resource for a node with mem as 450 and vcores as 10 (mem has increeased but vcores has decreased)
+	// delta resource for a node with mem as 450 and vcores as 10 (mem has increeased but vcores has decreased)
 	delta, err = resources.NewResourceFromConf(map[string]string{"memory": "50", "vcore": "-20"})
 	assert.NilError(t, err, "failed to create resource")
 	partition.updateNode(delta)

--- a/pkg/scheduler/partition_test.go
+++ b/pkg/scheduler/partition_test.go
@@ -1079,3 +1079,55 @@ func TestUpdateRootQueue(t *testing.T) {
 	assert.Equal(t, partition.GetQueue("root.leaf").CurrentState(), objects.Draining.String(), "leaf queue should have been marked for removal")
 	assert.Equal(t, partition.GetQueue("root.parent").CurrentState(), objects.Draining.String(), "parent queue should have been marked for removal")
 }
+
+func TestUpdateNode(t *testing.T) {
+	partition, err := newBasePartition()
+	assert.NilError(t, err, "test partition create failed with error")
+
+	newRes, err := resources.NewResourceFromConf(map[string]string{"memory": "400", "vcore": "30"})
+	assert.NilError(t, err, "failed to create resource")
+
+	err = partition.AddNode(newNodeMaxResource("test", newRes), nil)
+	assert.NilError(t, err, "test node add failed unexpected")
+	assert.Equal(t, 1, len(partition.nodes), "node list not correct")
+
+	if !resources.Equals(newRes, partition.GetTotalPartitionResource()) {
+		t.Errorf("Expected partition resource %s, doesn't match with actual partition resource %s", newRes, partition.GetTotalPartitionResource())
+	}
+
+	//delta resource for a node with mem as 450 and vcores as 40 (both mem and vcores has increeased)
+	delta, err := resources.NewResourceFromConf(map[string]string{"memory": "50", "vcore": "10"})
+	assert.NilError(t, err, "failed to create resource")
+	partition.updateNode(delta)
+
+	expectedRes, err := resources.NewResourceFromConf(map[string]string{"memory": "450", "vcore": "40"})
+	assert.NilError(t, err, "failed to create resource")
+
+	if !resources.Equals(expectedRes, partition.GetTotalPartitionResource()) {
+		t.Errorf("Expected partition resource %s, doesn't match with actual partition resource %s", expectedRes, partition.GetTotalPartitionResource())
+	}
+
+	///delta resource for a node with mem as 400 and vcores as 30 (both mem and vcores has decreased)
+	delta, err = resources.NewResourceFromConf(map[string]string{"memory": "-50", "vcore": "-10"})
+	assert.NilError(t, err, "failed to create resource")
+	partition.updateNode(delta)
+
+	expectedRes, err = resources.NewResourceFromConf(map[string]string{"memory": "400", "vcore": "30"})
+	assert.NilError(t, err, "failed to create resource")
+
+	if !resources.Equals(expectedRes, partition.GetTotalPartitionResource()) {
+		t.Errorf("Expected partition resource %s, doesn't match with actual partition resource %s", expectedRes, partition.GetTotalPartitionResource())
+	}
+
+	//delta resource for a node with mem as 450 and vcores as 10 (mem has increeased but vcores has decreased)
+	delta, err = resources.NewResourceFromConf(map[string]string{"memory": "50", "vcore": "-20"})
+	assert.NilError(t, err, "failed to create resource")
+	partition.updateNode(delta)
+
+	expectedRes, err = resources.NewResourceFromConf(map[string]string{"memory": "450", "vcore": "10"})
+	assert.NilError(t, err, "failed to create resource")
+
+	if !resources.Equals(expectedRes, partition.GetTotalPartitionResource()) {
+		t.Errorf("Expected partition resource %s, doesn't match with actual partition resource %s", expectedRes, partition.GetTotalPartitionResource())
+	}
+}

--- a/pkg/scheduler/tests/operation_test.go
+++ b/pkg/scheduler/tests/operation_test.go
@@ -347,8 +347,7 @@ partitions:
 	assert.Equal(t, len(partitionInfo.GetNodes()), 1)
 	node1 := partitionInfo.GetNode("node-1:1234")
 	assert.Equal(t, int64(node1.GetCapacity().Resources[resources.MEMORY]), int64(100))
-	schedulingNode1 := ms.scheduler.GetClusterContext().
-		GetNode("node-1:1234", "[rm:123]default")
+	schedulingNode1 := ms.scheduler.GetClusterContext().GetNode("node-1:1234", "[rm:123]default")
 	assert.Equal(t, int64(schedulingNode1.GetAllocatedResource().Resources[resources.MEMORY]), int64(0))
 	assert.Equal(t, int64(schedulingNode1.GetAvailableResource().Resources[resources.MEMORY]), int64(100))
 
@@ -371,8 +370,7 @@ partitions:
 	})
 
 	assert.NilError(t, err, "UpdateRequest failed")
-	waitForAvailableNodeResource(t, ms.scheduler.GetClusterContext(), "[rm:123]default",
-		[]string{"node-1:1234"}, 300, 1000)
+	waitForAvailableNodeResource(t, ms.scheduler.GetClusterContext(), "[rm:123]default", []string{"node-1:1234"}, 300, 1000)
 	assert.Equal(t, int64(node1.GetCapacity().Resources[resources.MEMORY]), int64(300))
 	assert.Equal(t, int64(node1.GetCapacity().Resources[resources.VCORE]), int64(10))
 	assert.Equal(t, int64(schedulingNode1.GetAllocatedResource().Resources[resources.MEMORY]), int64(0))
@@ -404,8 +402,7 @@ partitions:
 		RmID: "rm:123",
 	})
 	assert.NilError(t, err, "UpdateRequest failed")
-	waitForAvailableNodeResource(t, ms.scheduler.GetClusterContext(), "[rm:123]default",
-		[]string{"node-1:1234"}, 100, 1000)
+	waitForAvailableNodeResource(t, ms.scheduler.GetClusterContext(), "[rm:123]default", []string{"node-1:1234"}, 100, 1000)
 	newRes, err = resources.NewResourceFromConf(map[string]string{"memory": "100", "vcore": "20"})
 	assert.NilError(t, err, "failed to create resource")
 	if !resources.Equals(newRes, partitionInfo.GetTotalPartitionResource()) {


### PR DESCRIPTION
Added updateNode in Partition object to update the partition resource and root queue resource whenever node resources changes.