### PR TITLE
YUNIKORN-418: Add "config" REST API

### DIFF
--- a/pkg/webservice/dao/error_info.go
+++ b/pkg/webservice/dao/error_info.go
@@ -1,0 +1,33 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package dao
+
+type YAPIError struct {
+	StatusCode  int    `json:"status_code"`
+	Message     string `json:"message"`
+	Description string `json:"description"`
+}
+
+func NewYAPIError(err error, statusCode int, message string) *YAPIError {
+	return &YAPIError{
+		StatusCode:  statusCode,
+		Message:     message,
+		Description: message,
+	}
+}

--- a/pkg/webservice/dao/error_info.go
+++ b/pkg/webservice/dao/error_info.go
@@ -25,9 +25,14 @@ type YAPIError struct {
 }
 
 func NewYAPIError(err error, statusCode int, message string) *YAPIError {
+	description := message
+	if err != nil {
+		description = message + ". Original Cause :" + err.Error()
+	}
+
 	return &YAPIError{
 		StatusCode:  statusCode,
 		Message:     message,
-		Description: message,
+		Description: description,
 	}
 }

--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -462,13 +462,17 @@ func createClusterConfig(w http.ResponseWriter, r *http.Request) {
 	writeHeaders(w)
 
 	queryParams := r.URL.Query()
-	_, dryRunExists := queryParams["dry_run"]
-	if len(queryParams) == 0 || !dryRunExists {
-		http.Error(w, "Mandatory parameters are missing in URL path. Please check the usage documentation", http.StatusBadRequest)
+	dryRun, dryRunExists := queryParams["dry_run"]
+	if !dryRunExists {
+		http.Error(w, "Dry run param is missing. Please check the usage documentation", http.StatusBadRequest)
 		return
 	}
-	if queryParams.Get("dry_run") != "1" {
-		http.Error(w, "Invalid query params. Please check the usage documentation", http.StatusBadRequest)
+	if dryRun[0] != "1" {
+		http.Error(w, "Invalid \"dry_run\" query param. Currently, only dry_run=1 is supported. Please check the usage documentation", http.StatusBadRequest)
+		return
+	}
+	if len(queryParams) != 1 {
+		http.Error(w, "Invalid query parameters. Please check the usage documentation", http.StatusBadRequest)
 		return
 	}
 	requestBytes, err := ioutil.ReadAll(r.Body)

--- a/pkg/webservice/handlers_test.go
+++ b/pkg/webservice/handlers_test.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"strings"
 	"testing"
@@ -447,7 +448,7 @@ func TestUpdateConfig(t *testing.T) {
 	resp := &MockResponseWriter{}
 	req, err := http.NewRequest("PUT", "", strings.NewReader(updatedConf))
 	assert.NilError(t, err, "Failed to create the request")
-	updateConfig(resp, req)
+	updateClusterConfig(resp, req)
 	assert.NilError(t, err, "No error expected")
 	assert.Equal(t, http.StatusOK, resp.statusCode, "No error expected")
 }
@@ -457,7 +458,7 @@ func TestUpdateConfigInvalidConf(t *testing.T) {
 	resp := &MockResponseWriter{}
 	req, err := http.NewRequest("PUT", "", strings.NewReader(invalidConf))
 	assert.NilError(t, err, "Failed to create the request")
-	updateConfig(resp, req)
+	updateClusterConfig(resp, req)
 	assert.Equal(t, http.StatusConflict, resp.statusCode, "Status code is wrong")
 	assert.Assert(t, len(string(resp.outputBytes)) > 0, "Error message is expected")
 }
@@ -710,4 +711,78 @@ func TestPartitions(t *testing.T) {
 			assert.Equal(t, part.Applications["total"], 0)
 		}
 	}
+}
+
+func TestCreateClusterConfig(t *testing.T) {
+	confTests := []struct {
+		content          string
+		expectedResponse dao.ValidateConfResponse
+	}{
+		{
+			content: baseConf,
+			expectedResponse: dao.ValidateConfResponse{
+				Allowed: true,
+				Reason:  "",
+			},
+		},
+		{
+			content: invalidConf,
+			expectedResponse: dao.ValidateConfResponse{
+				Allowed: false,
+				Reason:  "undefined policy: invalid",
+			},
+		},
+	}
+
+	configs.MockSchedulerConfigByData([]byte(configDefault))
+	var err error
+	schedulerContext, err = scheduler.NewClusterContext(rmID, policyGroup)
+	assert.NilError(t, err, "Error when load clusterInfo from config")
+	for _, test := range confTests {
+		// No err check: new request always returns correctly
+		//nolint: errcheck
+		req, _ := http.NewRequest("POST", "/ws/v1/config?dry_run=1", strings.NewReader(test.content))
+		rr := httptest.NewRecorder()
+		mux := http.HandlerFunc(createClusterConfig)
+		handler := loggingHandler(mux, "/ws/v1/config")
+		handler.ServeHTTP(rr, req)
+		var vcr dao.ValidateConfResponse
+		err = json.Unmarshal(rr.Body.Bytes(), &vcr)
+		assert.NilError(t, err, "failed to unmarshal ValidateConfResponse from response body")
+		assert.Equal(t, vcr.Allowed, test.expectedResponse.Allowed, "allowed flag incorrect")
+		assert.Equal(t, vcr.Reason, test.expectedResponse.Reason, "response text not as expected")
+	}
+
+	// When "dry_run" is not passed
+	//nolint: errcheck
+	req, err := http.NewRequest("POST", "/ws/v1/config", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rr := httptest.NewRecorder()
+	mux := http.HandlerFunc(createClusterConfig)
+	handler := loggingHandler(mux, "/ws/v1/config")
+	handler.ServeHTTP(rr, req)
+	fmt.Println("dd is " + rr.Body.String())
+
+	var errInfo dao.YAPIError
+	err = json.Unmarshal(rr.Body.Bytes(), &errInfo)
+	assert.NilError(t, err, "failed to unmarshal ValidateConfResponse from response body")
+	assert.Equal(t, errInfo.Message, "Mandatory parameters are missing in URL path. Please check the usage documentation\n", "JSON error message is incorrect")
+	assert.Equal(t, errInfo.StatusCode, http.StatusBadRequest)
+
+	// When "dry_run" value is invalid
+	//nolint: errcheck
+	req, err = http.NewRequest("POST", "/ws/v1/config?dry_run=0", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rr = httptest.NewRecorder()
+	mux = http.HandlerFunc(createClusterConfig)
+	handler = loggingHandler(mux, "/ws/v1/config?dry_run=0")
+	handler.ServeHTTP(rr, req)
+	err = json.Unmarshal(rr.Body.Bytes(), &errInfo)
+	assert.NilError(t, err, "failed to unmarshal ValidateConfResponse from response body")
+	assert.Equal(t, errInfo.Message, "Invalid query params. Please check the usage documentation\n", "JSON error message is incorrect")
+	assert.Equal(t, errInfo.StatusCode, http.StatusBadRequest)
 }

--- a/pkg/webservice/handlers_test.go
+++ b/pkg/webservice/handlers_test.go
@@ -763,12 +763,11 @@ func TestCreateClusterConfig(t *testing.T) {
 	mux := http.HandlerFunc(createClusterConfig)
 	handler := loggingHandler(mux, "/ws/v1/config")
 	handler.ServeHTTP(rr, req)
-	fmt.Println("dd is " + rr.Body.String())
 
 	var errInfo dao.YAPIError
 	err = json.Unmarshal(rr.Body.Bytes(), &errInfo)
 	assert.NilError(t, err, "failed to unmarshal ValidateConfResponse from response body")
-	assert.Equal(t, errInfo.Message, "Mandatory parameters are missing in URL path. Please check the usage documentation\n", "JSON error message is incorrect")
+	assert.Equal(t, errInfo.Message, "Dry run param is missing. Please check the usage documentation\n", "JSON error message is incorrect")
 	assert.Equal(t, errInfo.StatusCode, http.StatusBadRequest)
 
 	// When "dry_run" value is invalid
@@ -783,6 +782,6 @@ func TestCreateClusterConfig(t *testing.T) {
 	handler.ServeHTTP(rr, req)
 	err = json.Unmarshal(rr.Body.Bytes(), &errInfo)
 	assert.NilError(t, err, "failed to unmarshal ValidateConfResponse from response body")
-	assert.Equal(t, errInfo.Message, "Invalid query params. Please check the usage documentation\n", "JSON error message is incorrect")
+	assert.Equal(t, errInfo.Message, "Invalid \"dry_run\" query param. Currently, only dry_run=1 is supported. Please check the usage documentation\n", "JSON error message is incorrect")
 	assert.Equal(t, errInfo.StatusCode, http.StatusBadRequest)
 }

--- a/pkg/webservice/handlers_test.go
+++ b/pkg/webservice/handlers_test.go
@@ -756,9 +756,7 @@ func TestCreateClusterConfig(t *testing.T) {
 	// When "dry_run" is not passed
 	//nolint: errcheck
 	req, err := http.NewRequest("POST", "/ws/v1/config", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err, "Problem in creating the request")
 	rr := httptest.NewRecorder()
 	mux := http.HandlerFunc(createClusterConfig)
 	handler := loggingHandler(mux, "/ws/v1/config")
@@ -773,9 +771,7 @@ func TestCreateClusterConfig(t *testing.T) {
 	// When "dry_run" value is invalid
 	//nolint: errcheck
 	req, err = http.NewRequest("POST", "/ws/v1/config?dry_run=0", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err, "Problem in creating the request")
 	rr = httptest.NewRecorder()
 	mux = http.HandlerFunc(createClusterConfig)
 	handler = loggingHandler(mux, "/ws/v1/config?dry_run=0")

--- a/pkg/webservice/routes.go
+++ b/pkg/webservice/routes.go
@@ -102,7 +102,15 @@ var webRoutes = routes{
 		"Scheduler",
 		"PUT",
 		"/ws/v1/config",
-		updateConfig,
+		updateClusterConfig,
+	},
+
+	// endpoint to update the current conf
+	route{
+		"Scheduler",
+		"POST",
+		"/ws/v1/config",
+		createClusterConfig,
 	},
 
 	// endpoint to validate conf

--- a/pkg/webservice/routes.go
+++ b/pkg/webservice/routes.go
@@ -105,7 +105,7 @@ var webRoutes = routes{
 		updateClusterConfig,
 	},
 
-	// endpoint to update the current conf
+	// endpoint to create the conf, but currently limited for conf validation purpose alone
 	route{
 		"Scheduler",
 		"POST",

--- a/pkg/webservice/webservice.go
+++ b/pkg/webservice/webservice.go
@@ -20,6 +20,7 @@ package webservice
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"sync"
@@ -31,6 +32,7 @@ import (
 	"github.com/apache/incubator-yunikorn-core/pkg/log"
 	"github.com/apache/incubator-yunikorn-core/pkg/metrics/history"
 	"github.com/apache/incubator-yunikorn-core/pkg/scheduler"
+	"github.com/apache/incubator-yunikorn-core/pkg/webservice/dao"
 )
 
 var imHistory *history.InternalMetricsHistory
@@ -45,7 +47,6 @@ func newRouter() *mux.Router {
 	router := mux.NewRouter().StrictSlash(true)
 	for _, webRoute := range webRoutes {
 		handler := loggingHandler(webRoute.HandlerFunc, webRoute.Name)
-
 		router.
 			Methods(webRoute.Method).
 			Path(webRoute.Pattern).
@@ -58,12 +59,38 @@ func newRouter() *mux.Router {
 func loggingHandler(inner http.Handler, name string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
-
-		inner.ServeHTTP(w, r)
-
+		rw := &YResponseWriter{ResponseWriter: w, statusCode: -1}
+		inner.ServeHTTP(rw, r)
+		var body = string(rw.body)
+		if rw.statusCode != 200 && rw.statusCode != -1 {
+			errorInfo := dao.NewYAPIError(nil, rw.statusCode, body)
+			if err := json.NewEncoder(w).Encode(errorInfo); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
+		}
 		log.Logger().Debug(fmt.Sprintf("%s\t%s\t%s\t%s",
 			r.Method, r.RequestURI, name, time.Since(start)))
 	})
+}
+
+type YResponseWriter struct {
+	http.ResponseWriter
+	statusCode int
+	body       []byte
+}
+
+func (rw *YResponseWriter) Write(bytes []byte) (int, error) {
+	rw.body = bytes
+	if rw.statusCode == -1 {
+		rw.ResponseWriter.Write(bytes)
+	}
+	return len(bytes), nil
+}
+
+func (rw *YResponseWriter) WriteHeader(code int) {
+	rw.statusCode = code
+	rw.ResponseWriter.WriteHeader(code)
+	writeHeaders(rw.ResponseWriter)
 }
 
 // TODO we need the port to be configurable


### PR DESCRIPTION
First cut implementation. In addition, response middleware has been added to return error also in json format and used httptest package for unit testing the same.