### PR TITLE
[YUNIKORN-494]Rename the AllocationRelease Request and Response in core

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ go 1.12
 
 require (
 	github.com/HdrHistogram/hdrhistogram-go v0.9.0 // indirect
-	github.com/apache/incubator-yunikorn-scheduler-interface v0.9.1-0.20200901200728-b9033558f319
+	github.com/apache/incubator-yunikorn-scheduler-interface v0.9.1-0.20201215141356-df4d86d2197b
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/golang/protobuf v1.4.0 // indirect
 	github.com/gorilla/mux v1.7.3

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/apache/incubator-yunikorn-scheduler-interface v0.9.1-0.20200827013520
 github.com/apache/incubator-yunikorn-scheduler-interface v0.9.1-0.20200827013520-ec2f681ecb5b/go.mod h1:ObMs03XFbnmpGD81jYvdUDEVZbHvz8W6dWH5nGDCjc0=
 github.com/apache/incubator-yunikorn-scheduler-interface v0.9.1-0.20200901200728-b9033558f319 h1:I12nCcXdHe6W4oysVejFHfQDy0Ix0r+ZHdfooyEoldo=
 github.com/apache/incubator-yunikorn-scheduler-interface v0.9.1-0.20200901200728-b9033558f319/go.mod h1:ObMs03XFbnmpGD81jYvdUDEVZbHvz8W6dWH5nGDCjc0=
+github.com/apache/incubator-yunikorn-scheduler-interface v0.9.1-0.20201215141356-df4d86d2197b h1:dxncLtkTwtqUB6pgsVVw52+Ni3ZXG2BPnLrSrubcRZA=
+github.com/apache/incubator-yunikorn-scheduler-interface v0.9.1-0.20201215141356-df4d86d2197b/go.mod h1:ObMs03XFbnmpGD81jYvdUDEVZbHvz8W6dWH5nGDCjc0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/pkg/rmproxy/rmevent/events.go
+++ b/pkg/rmproxy/rmevent/events.go
@@ -71,7 +71,7 @@ type RMRejectedAllocationAskEvent struct {
 
 type RMReleaseAllocationEvent struct {
 	RmID                string
-	ReleasedAllocations []*si.AllocationReleaseResponse
+	ReleasedAllocations []*si.AllocationRelease
 }
 
 type RMNodeUpdateEvent struct {

--- a/pkg/scheduler/tests/mockscheduler_test.go
+++ b/pkg/scheduler/tests/mockscheduler_test.go
@@ -144,7 +144,7 @@ func (m *mockScheduler) addAppRequest(appID, allocID string, resource *si.Resour
 func (m *mockScheduler) releaseAllocRequest(appID, uuid string) error {
 	return m.proxy.Update(&si.UpdateRequest{
 		Releases: &si.AllocationReleasesRequest{
-			AllocationsToRelease: []*si.AllocationReleaseRequest{
+			AllocationsToRelease: []*si.AllocationRelease{
 				{
 					ApplicationID: appID,
 					UUID:          uuid,

--- a/pkg/scheduler/tests/smoke_test.go
+++ b/pkg/scheduler/tests/smoke_test.go
@@ -319,14 +319,14 @@ partitions:
 
 	updateRequest := &si.UpdateRequest{
 		Releases: &si.AllocationReleasesRequest{
-			AllocationsToRelease: make([]*si.AllocationReleaseRequest, 0),
+			AllocationsToRelease: make([]*si.AllocationRelease, 0),
 		},
 		RmID: "rm:123",
 	}
 
 	// Release all allocations
 	for _, v := range ms.mockRM.getAllocations() {
-		updateRequest.Releases.AllocationsToRelease = append(updateRequest.Releases.AllocationsToRelease, &si.AllocationReleaseRequest{
+		updateRequest.Releases.AllocationsToRelease = append(updateRequest.Releases.AllocationsToRelease, &si.AllocationRelease{
 			UUID:          v.UUID,
 			ApplicationID: v.ApplicationID,
 			PartitionName: v.PartitionName,
@@ -870,9 +870,9 @@ partitions:
 			assert.Equal(t, len(ms.mockRM.getAllocations()), 10, "number of RM allocations incorrect")
 
 			// release all allocated allocations
-			allocReleases := make([]*si.AllocationReleaseRequest, 0)
+			allocReleases := make([]*si.AllocationRelease, 0)
 			for _, alloc := range ms.mockRM.getAllocations() {
-				allocReleases = append(allocReleases, &si.AllocationReleaseRequest{
+				allocReleases = append(allocReleases, &si.AllocationRelease{
 					PartitionName: "default",
 					ApplicationID: appID1,
 					UUID:          alloc.UUID,


### PR DESCRIPTION
Because the new scheduler-interface change we need to rename AllocationReleaseRequest and AllocationReleaseResponse.
Please review @yangwwei 
Thanks.