### PR TITLE
[YUNIKORN-542] App submission time in nano seconds

### DIFF
--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -296,7 +296,7 @@ func getApplicationJSON(app *objects.Application) *dao.ApplicationDAOInfo {
 		UsedResource:   app.GetAllocatedResource().DAOString(),
 		Partition:      app.Partition,
 		QueueName:      app.QueueName,
-		SubmissionTime: app.SubmissionTime.Unix(),
+		SubmissionTime: app.SubmissionTime.UnixNano(),
 		Allocations:    allocationInfos,
 		State:          app.CurrentState(),
 	}


### PR DESCRIPTION
Times in the rest interface should be in nano seconds. The application
submission time is converted into seconds causing display issues on
the web UI.