### PR TITLE
[YUNIKORN-572] deadlock in moveTerminatedApp

### DIFF
--- a/pkg/scheduler/objects/application.go
+++ b/pkg/scheduler/objects/application.go
@@ -1054,6 +1054,8 @@ func (sa *Application) UnSetQueue() {
 	if sa.queue != nil {
 		sa.queue.RemoveApplication(sa)
 	}
+	sa.Lock()
+	defer sa.Unlock()
 	sa.queue = nil
 }
 


### PR DESCRIPTION
Move the queue removal of the application outside of the partition lock.
The manipulations of the application object must not take the partition
lock. The application object itself handles locking as needed.

Add comments on locking for the partition.