### PR TITLE
[YUNIKORN-578] dynamic queue quota for gang size

### DIFF
--- a/pkg/scheduler/objects/queue.go
+++ b/pkg/scheduler/objects/queue.go
@@ -37,7 +37,7 @@ import (
 	"github.com/apache/incubator-yunikorn-core/pkg/webservice/dao"
 )
 
-const appTagNamespaceResourceQuota = "namespace.resourcequota"
+const AppTagNamespaceResourceQuota = "namespace.resourcequota"
 
 // Represents Queue inside Scheduler
 type Queue struct {
@@ -458,7 +458,7 @@ func (sq *Queue) AddApplication(app *Application) {
 	sq.applications[app.ApplicationID] = app
 	// YUNIKORN-199: update the quota from the namespace
 	// get the tag with the quota
-	quota := app.GetTag(appTagNamespaceResourceQuota)
+	quota := app.GetTag(AppTagNamespaceResourceQuota)
 	if quota == "" {
 		return
 	}

--- a/pkg/scheduler/objects/queue_test.go
+++ b/pkg/scheduler/objects/queue_test.go
@@ -280,7 +280,7 @@ func TestAddApplicationWithTag(t *testing.T) {
 			"first": 10,
 		})
 	tags := make(map[string]string)
-	tags[appTagNamespaceResourceQuota] = "{\"resources\":{\"first\":{\"value\":10}}}"
+	tags[AppTagNamespaceResourceQuota] = "{\"resources\":{\"first\":{\"value\":10}}}"
 	// add apps again now with the tag set
 	app = newApplicationWithTags("app-3", "default", "root.leaf-man", tags)
 	leaf.AddApplication(app)
@@ -296,7 +296,7 @@ func TestAddApplicationWithTag(t *testing.T) {
 	}
 
 	// set to illegal limit (0 value)
-	tags[appTagNamespaceResourceQuota] = "{\"resources\":{\"first\":{\"value\":0}}}"
+	tags[AppTagNamespaceResourceQuota] = "{\"resources\":{\"first\":{\"value\":0}}}"
 	app = newApplicationWithTags("app-4", "default", "root.leaf-un", tags)
 	leafUn.AddApplication(app)
 	assert.Equal(t, len(leaf.applications), 2, "Application was not added to the Dynamic queue as expected")

--- a/pkg/scheduler/utilities_test.go
+++ b/pkg/scheduler/utilities_test.go
@@ -34,6 +34,7 @@ import (
 const (
 	appID1    = "app-1"
 	appID2    = "app-2"
+	appID3    = "app-3"
 	nodeID1   = "node-1"
 	nodeID2   = "node-2"
 	defQueue  = "root.default"
@@ -132,6 +133,33 @@ func newLimitedPartition(resLimit map[string]string) (*PartitionContext, error) 
 	return newPartitionContext(conf, rmID, nil)
 }
 
+func newPlacementPartition() (*PartitionContext, error) {
+	conf := configs.PartitionConfig{
+		Name: "test",
+		Queues: []configs.QueueConfig{
+			{
+				Name:      "root",
+				Parent:    true,
+				SubmitACL: "*",
+				Queues:    nil,
+			},
+		},
+		PlacementRules: []configs.PlacementRule{
+			{
+				Name:   "tag",
+				Create: true,
+				Parent: nil,
+				Value:  "taskqueue",
+			},
+		},
+		Limits:         nil,
+		Preemption:     configs.PartitionPreemptionConfig{},
+		NodeSortPolicy: configs.NodeSortingPolicy{},
+	}
+
+	return newPartitionContext(conf, rmID, nil)
+}
+
 func newApplication(appID, partition, queueName string) *objects.Application {
 	siApp := &si.AddApplicationRequest{
 		ApplicationID: appID,
@@ -142,11 +170,16 @@ func newApplication(appID, partition, queueName string) *objects.Application {
 }
 
 func newApplicationTG(appID, partition, queueName string, task *resources.Resource) *objects.Application {
+	return newApplicationTGTags(appID,partition, queueName, task, nil)
+}
+
+func newApplicationTGTags(appID, partition, queueName string, task *resources.Resource, tags map[string]string) *objects.Application {
 	siApp := &si.AddApplicationRequest{
 		ApplicationID:  appID,
 		QueueName:      queueName,
 		PartitionName:  partition,
 		PlaceholderAsk: task.ToProto(),
+		Tags:           tags,
 	}
 	return objects.NewApplication(siApp, security.UserGroup{}, nil, rmID)
 }

--- a/pkg/scheduler/utilities_test.go
+++ b/pkg/scheduler/utilities_test.go
@@ -170,7 +170,7 @@ func newApplication(appID, partition, queueName string) *objects.Application {
 }
 
 func newApplicationTG(appID, partition, queueName string, task *resources.Resource) *objects.Application {
-	return newApplicationTGTags(appID,partition, queueName, task, nil)
+	return newApplicationTGTags(appID, partition, queueName, task, nil)
 }
 
 func newApplicationTGTags(appID, partition, queueName string, task *resources.Resource, tags map[string]string) *objects.Application {


### PR DESCRIPTION
A dynamic queue which is linked to a namespace and the quota linked to
that fails to properly enforce gang request size against that quota.
This only happens for the first application submitted to the namespace
and queue. The order for queue create, app addition and quota checks is
incorrect.