### PR TITLE
[YUNIKORN-574] Wait for placeholder cleanup

### DIFF
--- a/pkg/scheduler/objects/application_state.go
+++ b/pkg/scheduler/objects/application_state.go
@@ -38,7 +38,6 @@ type applicationEvent int
 
 const (
 	RunApplication applicationEvent = iota
-	WaitApplication
 	RejectApplication
 	CompleteApplication
 	FailApplication
@@ -46,7 +45,7 @@ const (
 )
 
 func (ae applicationEvent) String() string {
-	return [...]string{"runApplication", "waitApplication", "rejectApplication", "completeApplication", "KillApplication", "expireApplication"}[ae]
+	return [...]string{"runApplication", "rejectApplication", "completeApplication", "failApplication", "expireApplication"}[ae]
 }
 
 // ----------------------------------
@@ -59,15 +58,16 @@ const (
 	Accepted
 	Starting
 	Running
-	Waiting
 	Rejected
+	Completing
 	Completed
+	Failing
 	Failed
 	Expired
 )
 
 func (as applicationState) String() string {
-	return [...]string{"New", "Accepted", "Starting", "Running", "Waiting", "Rejected", "Completed", "Failed", "Expired"}[as]
+	return [...]string{"New", "Accepted", "Starting", "Running", "Rejected", "Completing", "Completed", "Failing", "Failed", "Expired"}[as]
 }
 
 func NewAppState() *fsm.FSM {
@@ -87,23 +87,27 @@ func NewAppState() *fsm.FSM {
 				Dst:  Starting.String(),
 			}, {
 				Name: RunApplication.String(),
-				Src:  []string{Running.String(), Starting.String(), Waiting.String()},
+				Src:  []string{Running.String(), Starting.String(), Completing.String()},
 				Dst:  Running.String(),
 			}, {
 				Name: CompleteApplication.String(),
-				Src:  []string{Running.String(), Starting.String(), Waiting.String()},
+				Src:  []string{Accepted.String(), Running.String(), Starting.String()},
+				Dst:  Completing.String(),
+			}, {
+				Name: CompleteApplication.String(),
+				Src:  []string{Completing.String()},
 				Dst:  Completed.String(),
 			}, {
-				Name: WaitApplication.String(),
-				Src:  []string{Accepted.String(), Running.String(), Starting.String()},
-				Dst:  Waiting.String(),
+				Name: FailApplication.String(),
+				Src:  []string{Accepted.String(), New.String(), Running.String(), Starting.String(), Completing.String()},
+				Dst:  Failing.String(),
 			}, {
 				Name: FailApplication.String(),
-				Src:  []string{Accepted.String(), Failed.String(), New.String(), Running.String(), Starting.String(), Waiting.String()},
+				Src:  []string{Failing.String()},
 				Dst:  Failed.String(),
 			}, {
 				Name: ExpireApplication.String(),
-				Src:  []string{Completed.String()},
+				Src:  []string{Completed.String(), Failed.String()},
 				Dst:  Expired.String(),
 			},
 		},
@@ -127,7 +131,7 @@ func NewAppState() *fsm.FSM {
 			fmt.Sprintf("enter_%s", Starting.String()): func(event *fsm.Event) {
 				setTimer(startingTimeout, event, RunApplication)
 			},
-			fmt.Sprintf("enter_%s", Waiting.String()): func(event *fsm.Event) {
+			fmt.Sprintf("enter_%s", Completing.String()): func(event *fsm.Event) {
 				setTimer(waitingTimeout, event, CompleteApplication)
 			},
 			fmt.Sprintf("leave_%s", New.String()): func(event *fsm.Event) {
@@ -147,6 +151,9 @@ func NewAppState() *fsm.FSM {
 				app := setTimer(completedTimeout, event, ExpireApplication)
 				app.executeTerminatedCallback()
 				app.clearPlaceholderTimer()
+			},
+			fmt.Sprintf("enter_%s", Failing.String()): func(event *fsm.Event) {
+				event.Args[0].(*Application).failAppIfPossible()
 			},
 			fmt.Sprintf("enter_%s", Failed.String()): func(event *fsm.Event) {
 				app := setTimer(completedTimeout, event, ExpireApplication)

--- a/pkg/scheduler/objects/application_state.go
+++ b/pkg/scheduler/objects/application_state.go
@@ -132,7 +132,7 @@ func NewAppState() *fsm.FSM {
 				setTimer(startingTimeout, event, RunApplication)
 			},
 			fmt.Sprintf("enter_%s", Completing.String()): func(event *fsm.Event) {
-				setTimer(waitingTimeout, event, CompleteApplication)
+				setTimer(completingTimeout, event, CompleteApplication)
 			},
 			fmt.Sprintf("leave_%s", New.String()): func(event *fsm.Event) {
 				metrics.GetSchedulerMetrics().IncTotalApplicationsAdded()
@@ -148,7 +148,7 @@ func NewAppState() *fsm.FSM {
 			},
 			fmt.Sprintf("enter_%s", Completed.String()): func(event *fsm.Event) {
 				metrics.GetSchedulerMetrics().IncTotalApplicationsCompleted()
-				app := setTimer(completedTimeout, event, ExpireApplication)
+				app := setTimer(terminatedTimeout, event, ExpireApplication)
 				app.executeTerminatedCallback()
 				app.clearPlaceholderTimer()
 			},
@@ -156,7 +156,7 @@ func NewAppState() *fsm.FSM {
 				event.Args[0].(*Application).failAppIfPossible()
 			},
 			fmt.Sprintf("enter_%s", Failed.String()): func(event *fsm.Event) {
-				app := setTimer(completedTimeout, event, ExpireApplication)
+				app := setTimer(terminatedTimeout, event, ExpireApplication)
 				app.executeTerminatedCallback()
 			},
 		},

--- a/pkg/scheduler/objects/application_test.go
+++ b/pkg/scheduler/objects/application_test.go
@@ -731,11 +731,11 @@ func TestStateTimeOut(t *testing.T) {
 }
 
 func TestCompleted(t *testing.T) {
-	waitingTimeout = time.Millisecond * 100
-	completedTimeout = time.Millisecond * 100
+	completingTimeout = time.Millisecond * 100
+	terminatedTimeout = time.Millisecond * 100
 	defer func() {
-		waitingTimeout = time.Second * 30
-		completedTimeout = 30 * 24 * time.Hour
+		completingTimeout = time.Second * 30
+		terminatedTimeout = 30 * 24 * time.Hour
 	}()
 	app := newApplication(appID1, "default", "root.a")
 	err := app.HandleApplicationEvent(RunApplication)

--- a/pkg/scheduler/objects/application_test.go
+++ b/pkg/scheduler/objects/application_test.go
@@ -320,7 +320,7 @@ func TestAllocAskStateChange(t *testing.T) {
 	assert.Assert(t, app.IsAccepted(), "Application should be in accepted state")
 	// make sure the state changes to waiting
 	assert.Equal(t, app.RemoveAllocationAsk(aKey), 0, "ask should have been removed, no reservations")
-	assert.Assert(t, app.IsWaiting(), "Application should be in waiting state")
+	assert.Assert(t, app.IsCompleting(), "Application should be in waiting state")
 
 	// make sure the state changes back correctly
 	err = app.AddAllocationAsk(ask)
@@ -329,7 +329,7 @@ func TestAllocAskStateChange(t *testing.T) {
 
 	// and back to waiting again, now from running
 	assert.Equal(t, app.RemoveAllocationAsk(aKey), 0, "ask should have been removed, no reservations")
-	assert.Assert(t, app.IsWaiting(), "Application should be in waiting state")
+	assert.Assert(t, app.IsCompleting(), "Application should be in waiting state")
 }
 
 // test recover ask
@@ -550,7 +550,7 @@ func TestStateChangeOnUpdate(t *testing.T) {
 	// removing the ask should move it to waiting
 	released := app.RemoveAllocationAsk(askID)
 	assert.Equal(t, released, 0, "allocation ask should not have been reserved")
-	assert.Assert(t, app.IsWaiting(), "application did not change to waiting state: %s", app.CurrentState())
+	assert.Assert(t, app.IsCompleting(), "application did not change to waiting state: %s", app.CurrentState())
 
 	// start with a fresh state machine
 	app = newApplication(appID1, "default", "root.unknown")
@@ -579,7 +579,7 @@ func TestStateChangeOnUpdate(t *testing.T) {
 
 	// remove the allocation, ask has been removed so nothing left
 	app.RemoveAllocation(uuid)
-	assert.Assert(t, app.IsWaiting(), "Application did not change as expected: %s", app.CurrentState())
+	assert.Assert(t, app.IsCompleting(), "Application did not change as expected: %s", app.CurrentState())
 }
 
 func TestStateChangeOnPlaceholderAdd(t *testing.T) {
@@ -606,7 +606,7 @@ func TestStateChangeOnPlaceholderAdd(t *testing.T) {
 	// removing the ask should move it to waiting
 	released := app.RemoveAllocationAsk(askID)
 	assert.Equal(t, released, 0, "allocation ask should not have been reserved")
-	assert.Assert(t, app.IsWaiting(), "application did not change to waiting state: %s", app.CurrentState())
+	assert.Assert(t, app.IsCompleting(), "application did not change to waiting state: %s", app.CurrentState())
 
 	// start with a fresh state machine
 	app = newApplication(appID1, "default", "root.unknown")
@@ -633,11 +633,11 @@ func TestStateChangeOnPlaceholderAdd(t *testing.T) {
 	// removing the ask should move the application into the waiting state, because the allocation is only a placeholder allocation
 	released = app.RemoveAllocationAsk(askID)
 	assert.Equal(t, released, 0, "allocation ask should not have been reserved")
-	assert.Assert(t, app.IsWaiting(), "Application should have stayed same, changed unexpectedly: %s", app.CurrentState())
+	assert.Assert(t, app.IsCompleting(), "Application should have stayed same, changed unexpectedly: %s", app.CurrentState())
 
 	// remove the allocation, ask has been removed so nothing left
 	app.RemoveAllocation(uuid)
-	assert.Assert(t, app.IsWaiting(), "Application did not change as expected: %s", app.CurrentState())
+	assert.Assert(t, app.IsCompleting(), "Application did not change as expected: %s", app.CurrentState())
 }
 
 func TestAllocations(t *testing.T) {
@@ -740,9 +740,9 @@ func TestCompleted(t *testing.T) {
 	app := newApplication(appID1, "default", "root.a")
 	err := app.HandleApplicationEvent(RunApplication)
 	assert.NilError(t, err, "no error expected new to accepted (completed test)")
-	err = app.HandleApplicationEvent(WaitApplication)
+	err = app.HandleApplicationEvent(CompleteApplication)
 	assert.NilError(t, err, "no error expected accepted to waiting (completed test)")
-	assert.Assert(t, app.IsWaiting(), "App should be waiting")
+	assert.Assert(t, app.IsCompleting(), "App should be waiting")
 	// give it some time to run and progress
 	err = common.WaitFor(10*time.Microsecond, time.Millisecond*200, app.IsCompleted)
 	assert.NilError(t, err, "Application did not progress into Completed state")
@@ -864,7 +864,7 @@ func TestTimeoutPlaceholderProcessing_NoTimeoutSet(t *testing.T) {
 	// add the placeholder to the app
 	app.AddAllocation(ph)
 	assert.Assert(t, app.placeholderTimer != nil, "Placeholder timer should be initiated after the first placeholder allocation")
-	err = common.WaitFor(1*time.Millisecond, time.Millisecond*100, app.IsFailed)
+	err = common.WaitFor(1*time.Millisecond, time.Millisecond*200, app.IsFailing)
 	assert.NilError(t, err, "Application did not progress into Failed state")
 }
 

--- a/pkg/scheduler/partition_test.go
+++ b/pkg/scheduler/partition_test.go
@@ -1156,7 +1156,7 @@ func TestCompleteApp(t *testing.T) {
 	partition, err := newBasePartition()
 	assert.NilError(t, err, "partition create failed")
 	app := newApplication("completed", "default", defQueue)
-	app.SetState(objects.Waiting.String())
+	app.SetState(objects.Completing.String())
 	err = partition.AddApplication(app)
 	assert.NilError(t, err, "no error expected while adding the application")
 	assert.Assert(t, len(partition.applications) == 1, "the partition should have 1 app")

--- a/pkg/scheduler/tests/reservation_test.go
+++ b/pkg/scheduler/tests/reservation_test.go
@@ -157,7 +157,7 @@ func TestBasicReservation(t *testing.T) {
 // queue1 with app1 takes all nodes, leaving small space
 // queue2 with app2 and app3, app2 has largest requests and reserves both nodes
 // app3 is starved
-// kill app1 and make sure app2 gets its reservations filled followed by app3
+// fail app1 and make sure app2 gets its reservations filled followed by app3
 func TestReservationForTwoQueues(t *testing.T) {
 	ms := &mockScheduler{}
 	defer ms.Stop()

--- a/pkg/webservice/handlers_test.go
+++ b/pkg/webservice/handlers_test.go
@@ -25,12 +25,10 @@ import (
 	"reflect"
 	"strings"
 	"testing"
-	"time"
 
 	"gopkg.in/yaml.v2"
 	"gotest.tools/assert"
 
-	"github.com/apache/incubator-yunikorn-core/pkg/common"
 	"github.com/apache/incubator-yunikorn-core/pkg/common/configs"
 	"github.com/apache/incubator-yunikorn-core/pkg/common/resources"
 	"github.com/apache/incubator-yunikorn-core/pkg/common/security"
@@ -654,81 +652,33 @@ func TestPartitions(t *testing.T) {
 	// add a new app
 	addAndConfirmApplicationExists(t, partitionName, defaultPartition, "app-0")
 
-	// add a new app1
+	// add a new app1 - accepted
 	app1 := addAndConfirmApplicationExists(t, partitionName, defaultPartition, "app-1")
+	app1.SetState(objects.Accepted.String())
 
-	// app: new to accepted
-	err = app1.HandleApplicationEvent(objects.RunApplication)
-	assert.NilError(t, err, "no error expected new to accepted")
-	assert.Equal(t, app1.CurrentState(), objects.Accepted.String())
-
-	// add a new app2
+	// add a new app2 - starting
 	app2 := addAndConfirmApplicationExists(t, partitionName, defaultPartition, "app-2")
+	app2.SetState(objects.Starting.String())
 
-	// app2: new to starting
-	err = app2.HandleApplicationEvent(objects.RunApplication)
-	assert.NilError(t, err, "no error expected new to accepted (start test)")
-	err = app2.HandleApplicationEvent(objects.RunApplication)
-	assert.Assert(t, err, "no error expected new to starting")
-	assert.Equal(t, app2.CurrentState(), objects.Starting.String())
-
-	// add a new app3
+	// add a new app3 - running
 	app3 := addAndConfirmApplicationExists(t, partitionName, defaultPartition, "app-3")
+	app3.SetState(objects.Running.String())
 
-	// app3: new to running
-	err = app3.HandleApplicationEvent(objects.RunApplication)
-	assert.Assert(t, err, "no error expected new to accepted")
-	err = app3.HandleApplicationEvent(objects.RunApplication)
-	assert.Assert(t, err, "no error expected accepted to starting")
-	err = app3.HandleApplicationEvent(objects.RunApplication)
-	assert.NilError(t, err, "no error expected starting to running")
-	assert.Equal(t, app3.CurrentState(), objects.Running.String())
-
-	// add a new app4
+	// add a new app4 - completing
 	app4 := addAndConfirmApplicationExists(t, partitionName, defaultPartition, "app-4")
+	app4.SetState(objects.Completing.String())
 
-	// app4: new to accepted
-	err = app4.HandleApplicationEvent(objects.RunApplication)
-	assert.Assert(t, err, "no error expected new to accepted")
-
-	// app4: accepted to wait
-	err = app4.HandleApplicationEvent(objects.CompleteApplication)
-	assert.NilError(t, err, "no error expected accepted to waiting")
-	assert.Equal(t, app4.CurrentState(), objects.Completing.String())
-
-	// add a new app5
+	// add a new app5 - rejected
 	app5 := addAndConfirmApplicationExists(t, partitionName, defaultPartition, "app-5")
+	app5.SetState(objects.Rejected.String())
 
-	// app5: new to rejected
-	err = app5.HandleApplicationEvent(objects.RejectApplication)
-	assert.NilError(t, err, "no error expected new to rejected")
-	assert.Equal(t, app5.CurrentState(), objects.Rejected.String())
-
-	// add a new app6
+	// add a new app6 - completed
 	app6 := addAndConfirmApplicationExists(t, partitionName, defaultPartition, "app-6")
+	app6.SetState(objects.Completed.String())
 
-	// app6: new to starting
-	err = app6.HandleApplicationEvent(objects.RunApplication)
-	assert.NilError(t, err, "no error expected new to accepted")
-	err = app6.HandleApplicationEvent(objects.RunApplication)
-	assert.NilError(t, err, "no error expected accepted to starting")
-
-	// app6: starting to completed
-	err = app6.HandleApplicationEvent(objects.CompleteApplication)
-	assert.NilError(t, err, "no error expected starting to completing")
-	assert.Equal(t, app6.CurrentState(), objects.Completing.String())
-	err = app6.HandleApplicationEvent(objects.CompleteApplication)
-	assert.NilError(t, err, "no error expected completing to completed")
-	assert.Equal(t, app6.CurrentState(), objects.Completed.String())
-
-	// add a new app7
+	// add a new app7 - failed
 	app7 := addAndConfirmApplicationExists(t, partitionName, defaultPartition, "app-7")
-
-	// app7: new to killed
-	err = app7.HandleApplicationEvent(objects.FailApplication)
-	assert.NilError(t, err, "no error expected new to failed")
-	err = common.WaitFor(10*time.Microsecond, time.Millisecond*100, app7.IsFailed)
-	assert.NilError(t, err, "App should be in Failed state")
+	app7.SetState(objects.Failed.String())
 
 	NewWebApp(schedulerContext, nil)
 


### PR DESCRIPTION
With this fix a new state is introduced: Failing state. Also, Waiting state is renamed to Completing.
When we cleanup the placeholders, before moving the application into the terminating state (Completed or Failed)
we wait for the shim to release the allocations first.