### PR TITLE
[YUNIKORN-586] enhance placeholder cleanup on timeout

### DIFF
--- a/pkg/scheduler/objects/application_state.go
+++ b/pkg/scheduler/objects/application_state.go
@@ -99,7 +99,7 @@ func NewAppState() *fsm.FSM {
 				Dst:  Completed.String(),
 			}, {
 				Name: FailApplication.String(),
-				Src:  []string{Accepted.String(), New.String(), Running.String(), Starting.String(), Completing.String()},
+				Src:  []string{New.String(), Accepted.String(), Starting.String(), Running.String()},
 				Dst:  Failing.String(),
 			}, {
 				Name: FailApplication.String(),
@@ -151,9 +151,6 @@ func NewAppState() *fsm.FSM {
 				app := setTimer(terminatedTimeout, event, ExpireApplication)
 				app.executeTerminatedCallback()
 				app.clearPlaceholderTimer()
-			},
-			fmt.Sprintf("enter_%s", Failing.String()): func(event *fsm.Event) {
-				event.Args[0].(*Application).failAppIfPossible()
 			},
 			fmt.Sprintf("enter_%s", Failed.String()): func(event *fsm.Event) {
 				app := setTimer(terminatedTimeout, event, ExpireApplication)

--- a/pkg/scheduler/objects/application_state.go
+++ b/pkg/scheduler/objects/application_state.go
@@ -118,7 +118,7 @@ func NewAppState() *fsm.FSM {
 					log.Logger().Warn("The first argument is not an Application")
 					return
 				}
-				log.Logger().Debug("Application state transition",
+				log.Logger().Info("Application state transition",
 					zap.String("appID", app.ApplicationID),
 					zap.String("source", event.Src),
 					zap.String("destination", event.Dst),

--- a/pkg/scheduler/objects/application_state_test.go
+++ b/pkg/scheduler/objects/application_state_test.go
@@ -44,9 +44,9 @@ func TestAcceptStateTransition(t *testing.T) {
 
 	// accepted to failed
 	err = app.HandleApplicationEvent(FailApplication)
-	assert.NilError(t, err, "no error expected accepted to failed")
-	err = common.WaitFor(10*time.Microsecond, time.Millisecond*100, app.IsFailed)
-	assert.NilError(t, err, "App should be in Failed state")
+	assert.NilError(t, err, "no error expected accepted to failing")
+	err = common.WaitFor(10*time.Microsecond, time.Millisecond*100, app.IsFailing)
+	assert.NilError(t, err, "App should be in Failing state")
 }
 
 func TestRejectStateTransition(t *testing.T) {
@@ -64,9 +64,9 @@ func TestRejectStateTransition(t *testing.T) {
 	assert.Assert(t, err != nil, "error expected rejected to rejected")
 	assert.Equal(t, app.CurrentState(), Rejected.String())
 
-	// rejected to failed: error expected
+	// rejected to failing: error expected
 	err = app.HandleApplicationEvent(FailApplication)
-	assert.Assert(t, err != nil, "error expected rejected to failed")
+	assert.Assert(t, err != nil, "error expected rejected to failing")
 	assert.Equal(t, app.CurrentState(), Rejected.String())
 }
 
@@ -88,11 +88,11 @@ func TestStartStateTransition(t *testing.T) {
 	assert.Assert(t, err != nil, "error expected starting to rejected")
 	assert.Equal(t, appInfo.CurrentState(), Starting.String())
 
-	// start to failed
+	// start to failing
 	err = appInfo.HandleApplicationEvent(FailApplication)
-	assert.NilError(t, err, "no error expected starting to failed")
-	err = common.WaitFor(10*time.Microsecond, time.Millisecond*100, appInfo.IsFailed)
-	assert.NilError(t, err, "App should be in Failed state")
+	assert.NilError(t, err, "no error expected starting to failing")
+	err = common.WaitFor(10*time.Microsecond, time.Millisecond*100, appInfo.IsFailing)
+	assert.NilError(t, err, "App should be in Failing state")
 }
 
 func TestRunStateTransition(t *testing.T) {
@@ -120,16 +120,16 @@ func TestRunStateTransition(t *testing.T) {
 	assert.Assert(t, err != nil, "error expected running to rejected")
 	assert.Equal(t, appInfo.CurrentState(), Running.String())
 
-	// run to failed
+	// run to failing
 	err = appInfo.HandleApplicationEvent(FailApplication)
-	assert.NilError(t, err, "no error expected running to failed")
-	err = common.WaitFor(10*time.Microsecond, time.Millisecond*100, appInfo.IsFailed)
-	assert.NilError(t, err, "App should be in Failed state")
+	assert.NilError(t, err, "no error expected running to failing")
+	err = common.WaitFor(10*time.Microsecond, time.Millisecond*100, appInfo.IsFailing)
+	assert.NilError(t, err, "App should be in Failing state")
 
 	// run fails from failing
 	err = appInfo.HandleApplicationEvent(RunApplication)
-	assert.Assert(t, err != nil, "error expected failed to running")
-	assert.Equal(t, appInfo.CurrentState(), Failed.String())
+	assert.Assert(t, err != nil, "error expected failing to running")
+	assert.Equal(t, appInfo.CurrentState(), Failing.String())
 }
 
 func TestCompletedStateTransition(t *testing.T) {
@@ -169,9 +169,9 @@ func TestCompletedStateTransition(t *testing.T) {
 	assert.Assert(t, err != nil, "error expected completed to rejected")
 	assert.Equal(t, appInfo.CurrentState(), Completed.String())
 
-	// completed to failed: error expected
+	// completed to failing: error expected
 	err = appInfo.HandleApplicationEvent(FailApplication)
-	assert.Assert(t, err != nil, "error expected completed to failled")
+	assert.Assert(t, err != nil, "error expected completed to failing")
 	assert.Equal(t, appInfo.CurrentState(), Completed.String())
 
 	// completed fails from all completing
@@ -211,33 +211,27 @@ func TestCompletingStateTransition(t *testing.T) {
 	err = appInfo.HandleApplicationEvent(CompleteApplication)
 	assert.NilError(t, err, "no error expected running to completing")
 	assert.Equal(t, appInfo.CurrentState(), Completing.String())
-
-	// completing to failed
-	err = appInfo.HandleApplicationEvent(FailApplication)
-	assert.NilError(t, err, "no error expected completing to failed")
-	err = common.WaitFor(10*time.Microsecond, time.Millisecond*100, appInfo.IsFailed)
-	assert.NilError(t, err, "App should be in Failed state")
 }
 
 func TestFailedStateTransition(t *testing.T) {
-	// failed from all but rejected & completed
+	// failing from all but rejected & completed
 	appInfo := newApplication("app-00001", "default", "root.a")
 	assert.Equal(t, appInfo.CurrentState(), New.String())
 
-	// new to failed
+	// new to failing
 	err := appInfo.HandleApplicationEvent(FailApplication)
-	assert.NilError(t, err, "no error expected new to failed")
-	err = common.WaitFor(10*time.Microsecond, time.Millisecond*100, appInfo.IsFailed)
-	assert.NilError(t, err, "App should be in Failed state")
+	assert.NilError(t, err, "no error expected new to failing")
+	err = common.WaitFor(10*time.Microsecond, time.Millisecond*100, appInfo.IsFailing)
+	assert.NilError(t, err, "App should be in Failing state")
 
-	// failed to failed
+	// failing to failed
 	err = appInfo.HandleApplicationEvent(FailApplication)
-	assert.Assert(t, err != nil, "error expected failed to failed")
+	assert.NilError(t, err, "no error expected failing to failed")
 	assert.Assert(t, appInfo.IsFailed(), "App should be in Failed state")
 
 	// failed to rejected: error expected
 	err = appInfo.HandleApplicationEvent(RejectApplication)
-	assert.Assert(t, err != nil, "error expected failed to rejected")
+	assert.Assert(t, err != nil, "error expected failing to rejected")
 	err = common.WaitFor(10*time.Microsecond, time.Millisecond*100, appInfo.IsFailed)
 	assert.NilError(t, err, "App should be in Failed state")
 }


### PR DESCRIPTION
When the placeholder processing times out we could have placeholders in
two states: released or not released.
In the clean up we need to account for that. Placeholders that are marked
for release have a real allocation linked and are being processed by the
shim. The timeout should not release those placeholders.
This also needs to happen when the application is in Completing state.
On confirmation by the shim these placeholder replacements will trigger
a state change back to Running for the application. The placeholders
should thus no longer be available.