### PR TITLE
[YUNIKORN-645] Metrics endpoint doesn't export any metrics

### DIFF
--- a/pkg/webservice/handlers_test.go
+++ b/pkg/webservice/handlers_test.go
@@ -22,8 +22,6 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
-	"gopkg.in/yaml.v2"
-	"gotest.tools/assert"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -31,6 +29,8 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"gopkg.in/yaml.v2"
+	"gotest.tools/assert"
 
 	"github.com/apache/incubator-yunikorn-core/pkg/common/configs"
 	"github.com/apache/incubator-yunikorn-core/pkg/common/resources"

--- a/pkg/webservice/handlers_test.go
+++ b/pkg/webservice/handlers_test.go
@@ -22,7 +22,6 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"gopkg.in/yaml.v2"
 	"gotest.tools/assert"
 	"net/http"
@@ -30,6 +29,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	"github.com/apache/incubator-yunikorn-core/pkg/common/configs"
 	"github.com/apache/incubator-yunikorn-core/pkg/common/resources"
@@ -797,6 +798,4 @@ func TestMetricsNotEmpty(t *testing.T) {
 	handler := loggingHandler(mux, "/ws/v1/metrics")
 	handler.ServeHTTP(rr, req)
 	assert.Assert(t, len(rr.Body.Bytes()) > 0, "Metrics response should not be empty")
-	fmt.Println(string(rr.Body.Bytes()))
 }
-

--- a/pkg/webservice/webservice.go
+++ b/pkg/webservice/webservice.go
@@ -81,7 +81,7 @@ type YResponseWriter struct {
 
 func (rw *YResponseWriter) Write(bytes []byte) (int, error) {
 	rw.body = bytes
-	if rw.statusCode == -1 {
+	if rw.statusCode == -1  || rw.statusCode == http.StatusOK {
 		_, err := rw.ResponseWriter.Write(bytes)
 		if err != nil {
 			log.Logger().Error(fmt.Sprintf("Unable to serve response. Problem in writing the response \"%s\". Reason: %s", string(bytes), err.Error()))

--- a/pkg/webservice/webservice.go
+++ b/pkg/webservice/webservice.go
@@ -81,7 +81,7 @@ type YResponseWriter struct {
 
 func (rw *YResponseWriter) Write(bytes []byte) (int, error) {
 	rw.body = bytes
-	if rw.statusCode == -1  || rw.statusCode == http.StatusOK {
+	if rw.statusCode == -1 || rw.statusCode == http.StatusOK {
 		_, err := rw.ResponseWriter.Write(bytes)
 		if err != nil {
 			log.Logger().Error(fmt.Sprintf("Unable to serve response. Problem in writing the response \"%s\". Reason: %s", string(bytes), err.Error()))


### PR DESCRIPTION
### What is this PR for?

After YUNIKORN-418 we are using a custom http handler, what while reading the response checks if the response status is changed. If yes, the further reading was skipped. When accessing the metrics endpoint, the response is sent is multiple sub parts. Since after the first one the status will be changed, the processing of the response is skipped. 

With this PR I extended the check to skip the further processing if the status is changed and it is not 200-OK.

### What type of PR is it?
* [X] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?

https://issues.apache.org/jira/browse/YUNIKORN-645

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
