### PR TITLE
[YUNIKORN-627]The container history graph does not go down when pods are gone

### DIFF
--- a/pkg/metrics/init.go
+++ b/pkg/metrics/init.go
@@ -71,7 +71,7 @@ type CoreSchedulerMetrics interface {
 	// Metrics Ops related to released allocations
 	IncReleasedContainer()
 	AddReleasedContainers(value int)
-
+	getReleasedContainers() (int, error)
 	// Metrics Ops related to TotalApplicationsAdded
 	IncTotalApplicationsAdded()
 	AddTotalApplicationsAdded(value int)

--- a/pkg/metrics/metrics_collector.go
+++ b/pkg/metrics/metrics_collector.go
@@ -62,10 +62,19 @@ func (u *internalMetricsCollector) StartService() {
 					log.Logger().Warn("Could not encode totalApplications metric.", zap.Error(err))
 					totalAppsRunning = -1
 				}
-				totalContainersRunning, err := m.scheduler.getAllocatedContainers()
+				allocatedContainers, err := m.scheduler.getAllocatedContainers()
 				if err != nil {
-					log.Logger().Warn("Could not encode totalContainers metric.", zap.Error(err))
-					totalContainersRunning = -1
+					log.Logger().Warn("Could not encode allocatedContainers metric.", zap.Error(err))
+				}
+				releasedContainers, err := m.scheduler.getReleasedContainers()
+				if err != nil {
+					log.Logger().Warn("Could not encode releasedContainers metric.", zap.Error(err))
+				}
+				totalContainersRunning := allocatedContainers - releasedContainers
+				if totalContainersRunning < 0 {
+					log.Logger().Warn("Could not calculate the totalContainersRunning.",
+						zap.Int("allocatedContainers", allocatedContainers),
+						zap.Int("releasedContainers", releasedContainers))
 				}
 				u.metricsHistory.Store(totalAppsRunning, totalContainersRunning)
 			}

--- a/pkg/metrics/scheduler.go
+++ b/pkg/metrics/scheduler.go
@@ -254,6 +254,15 @@ func (m *SchedulerMetrics) AddReleasedContainers(value int) {
 	m.releasedContainers.Add(float64(value))
 }
 
+func (m *SchedulerMetrics) getReleasedContainers() (int, error) {
+	metricDto := &dto.Metric{}
+	err := m.releasedContainers.Write(metricDto)
+	if err == nil {
+		return int(*metricDto.Counter.Value), nil
+	}
+	return -1, err
+}
+
 // Metrics Ops related to allocationScheduleFailures
 func (m *SchedulerMetrics) IncRejectedContainer() {
 	m.rejectedContainers.Inc()


### PR DESCRIPTION
### What is this PR for?
Fix the metrics bug which get wrong amount of running containers.

### What type of PR is it?
* [ ] - Bug Fix

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-627

### How should this be tested?

### Screenshots (if appropriate)
![yunikorn-627](https://user-images.githubusercontent.com/61864060/116532258-a05eb980-a912-11eb-866f-ad577050bca4.png)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
