### PR TITLE
[YUNIKORN-758]Ignore unschedulable nodes for asks with certain tags

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ go 1.12
 
 require (
 	github.com/HdrHistogram/hdrhistogram-go v1.0.1 // indirect
-	github.com/apache/incubator-yunikorn-scheduler-interface v0.11.0
+	github.com/apache/incubator-yunikorn-scheduler-interface v0.11.1-0.20210723194917-606421b15601
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/google/uuid v1.2.0
 	github.com/gorilla/mux v1.7.3
@@ -49,3 +49,5 @@ require (
 	gotest.tools v2.2.0+incompatible
 	honnef.co/go/tools v0.0.1-2020.1.3 // indirect
 )
+
+replace github.com/apache/incubator-yunikorn-scheduler-interface => ../incubator-yunikorn-scheduler-interface

--- a/pkg/scheduler/objects/node.go
+++ b/pkg/scheduler/objects/node.go
@@ -312,8 +312,8 @@ func (sn *Node) ReplaceAllocation(uuid string, replace *Allocation) {
 // Taking into account resources marked for preemption if applicable.
 // If the proposed allocation does not fit false is returned.
 // TODO: remove when updating preemption
-func (sn *Node) CanAllocate(res *resources.Resource, preemptionPhase bool) bool {
-	err := sn.preAllocateCheck(res, "", preemptionPhase)
+func (sn *Node) CanAllocate(res *resources.Resource, preemptionPhase, ignore bool) bool {
+	err := sn.preAllocateCheck(res, "", preemptionPhase, ignore)
 	return err == nil
 }
 
@@ -358,27 +358,29 @@ func (sn *Node) preConditions(allocID string, allocate bool) bool {
 // Check if the node should be considered as a possible node to allocate on.
 //
 // This is a lock free call. No updates are made this only performs a pre allocate checks
-func (sn *Node) preAllocateCheck(res *resources.Resource, resKey string, preemptionPhase bool) error {
+func (sn *Node) preAllocateCheck(res *resources.Resource, resKey string, preemptionPhase, ignoreUnschedulable bool) error {
 	// shortcut if a node is not schedulable
-	if !sn.IsSchedulable() {
-		log.Logger().Debug("node is unschedulable",
-			zap.String("nodeID", sn.NodeID))
-		return fmt.Errorf("pre alloc check, node is unschedulable: %s", sn.NodeID)
+	if !ignoreUnschedulable {
+		if !sn.IsSchedulable() {
+			log.Logger().Debug("node is unschedulable",
+				zap.String("nodeID", sn.NodeID))
+			return fmt.Errorf("pre alloc check, node is unschedulable: %s", sn.NodeID)
+		}
+		// check if the node is reserved for this app/alloc
+		if sn.IsReserved() {
+			if !sn.isReservedForApp(resKey) {
+				log.Logger().Debug("pre alloc check: node reserved for different app or ask",
+					zap.String("nodeID", sn.NodeID),
+					zap.String("resKey", resKey))
+				return fmt.Errorf("pre alloc check: node %s reserved for different app or ask: %s", sn.NodeID, resKey)
+			}
+		}
 	}
 	// cannot allocate zero or negative resource
 	if !resources.StrictlyGreaterThanZero(res) {
 		log.Logger().Debug("pre alloc check: requested resource is zero",
 			zap.String("nodeID", sn.NodeID))
 		return fmt.Errorf("pre alloc check: requested resource is zero: %s", sn.NodeID)
-	}
-	// check if the node is reserved for this app/alloc
-	if sn.IsReserved() {
-		if !sn.isReservedForApp(resKey) {
-			log.Logger().Debug("pre alloc check: node reserved for different app or ask",
-				zap.String("nodeID", sn.NodeID),
-				zap.String("resKey", resKey))
-			return fmt.Errorf("pre alloc check: node %s reserved for different app or ask: %s", sn.NodeID, resKey)
-		}
 	}
 
 	// check if resources are available

--- a/pkg/scheduler/objects/node_test.go
+++ b/pkg/scheduler/objects/node_test.go
@@ -112,39 +112,39 @@ func TestPreAllocateCheck(t *testing.T) {
 	}
 
 	// special cases
-	if err := node.preAllocateCheck(nil, "", false); err == nil {
+	if err := node.preAllocateCheck(nil, "", false, false); err == nil {
 		t.Errorf("nil resource should not have fitted on node (no preemption)")
 	}
 	resNeg := resources.NewResourceFromMap(map[string]resources.Quantity{"first": -1})
-	if err := node.preAllocateCheck(resNeg, "", false); err == nil {
+	if err := node.preAllocateCheck(resNeg, "", false, false); err == nil {
 		t.Errorf("negative resource should not have fitted on node (no preemption)")
 	}
 	// Check if we can allocate on scheduling node
 	resSmall := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 5})
 	resLarge := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 15})
-	err := node.preAllocateCheck(resNode, "", false)
+	err := node.preAllocateCheck(resNode, "", false, false)
 	assert.NilError(t, err, "node resource should have fitted on node (no preemption)")
-	err = node.preAllocateCheck(resSmall, "", false)
+	err = node.preAllocateCheck(resSmall, "", false, false)
 	assert.NilError(t, err, "small resource should have fitted on node (no preemption)")
-	if err = node.preAllocateCheck(resLarge, "", false); err == nil {
+	if err = node.preAllocateCheck(resLarge, "", false, false); err == nil {
 		t.Errorf("too large resource should not have fitted on node (no preemption): %v", err)
 	}
 
 	// set allocated resource
 	node.AddAllocation(newAllocation(appID1, "UUID1", nodeID, "root.default", resSmall))
-	err = node.preAllocateCheck(resSmall, "", false)
+	err = node.preAllocateCheck(resSmall, "", false, false)
 	assert.NilError(t, err, "small resource should have fitted in available allocation (no preemption)")
-	if err = node.preAllocateCheck(resNode, "", false); err == nil {
+	if err = node.preAllocateCheck(resNode, "", false, false); err == nil {
 		t.Errorf("node resource should not have fitted in available allocation (no preemption): %v", err)
 	}
 
 	// set preempting resources
 	node.preempting = resSmall
-	err = node.preAllocateCheck(resSmall, "", true)
+	err = node.preAllocateCheck(resSmall, "", true, false)
 	assert.NilError(t, err, "small resource should have fitted in available allocation (preemption)")
-	err = node.preAllocateCheck(resNode, "", true)
+	err = node.preAllocateCheck(resNode, "", true, false)
 	assert.NilError(t, err, "node resource should have fitted in available allocation (preemption)")
-	if err = node.preAllocateCheck(resLarge, "", true); err == nil {
+	if err = node.preAllocateCheck(resLarge, "", true, false); err == nil {
 		t.Errorf("too large resource should not have fitted on node (preemption): %v", err)
 	}
 
@@ -157,22 +157,25 @@ func TestPreAllocateCheck(t *testing.T) {
 	// standalone reservation unreserve returns false as app is not reserved
 	reserve := newReservation(node, app, ask, false)
 	node.reservations[reserve.getKey()] = reserve
-	if err = node.preAllocateCheck(resSmall, "app-2", true); err == nil {
+	if err = node.preAllocateCheck(resSmall, "app-2", true, false); err == nil {
 		t.Errorf("node was reserved for different app but check passed: %v", err)
 	}
-	if err = node.preAllocateCheck(resSmall, "app-1|alloc-2", true); err == nil {
+	if err = node.preAllocateCheck(resSmall, "app-1|alloc-2", true, false); err == nil {
 		t.Errorf("node was reserved for this app but not the alloc and check passed: %v", err)
 	}
-	err = node.preAllocateCheck(resSmall, appID1, true)
+	err = node.preAllocateCheck(resSmall, appID1, true, false)
 	assert.NilError(t, err, "node was reserved for this app but check did not pass check")
-	err = node.preAllocateCheck(resSmall, "app-1|alloc-1", true)
+	err = node.preAllocateCheck(resSmall, "app-1|alloc-1", true, false)
 	assert.NilError(t, err, "node was reserved for this app/alloc but check did not pass check")
 
 	// Check if we can allocate on non scheduling node
 	node.SetSchedulable(false)
-	if err = node.preAllocateCheck(resSmall, "", false); err == nil {
+	if err = node.preAllocateCheck(resSmall, "", false, false); err == nil {
 		t.Errorf("node with scheduling set to false should not allow allocation: %v", err)
 	}
+	// Check the DaemonSet case in non scheduling node
+	err = node.preAllocateCheck(resSmall, "", false, true)
+	assert.NilError(t, err, "DaemonSet pod should ignore the tag of Unschedulable node")
 }
 
 // Only test the CanAllocate code, the used logic in preAllocateCheck has its own test
@@ -183,19 +186,24 @@ func TestCanAllocate(t *testing.T) {
 	}
 	// normal alloc
 	res := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 5})
-	if !node.CanAllocate(res, false) {
+	if !node.CanAllocate(res, false, false) {
 		t.Error("node should have accepted allocation")
 	}
 	// check one that pushes node over its size
 	res = resources.NewResourceFromMap(map[string]resources.Quantity{"first": 11})
-	if node.CanAllocate(res, false) {
+	if node.CanAllocate(res, false, false) {
+		t.Error("node should have rejected allocation (oversize)")
+	}
+
+	// check if the resource request is from DaemosSet
+	if node.CanAllocate(res, false, true) {
 		t.Error("node should have rejected allocation (oversize)")
 	}
 
 	// check if preempting adds to available
 	node.IncPreemptingResource(resources.NewResourceFromMap(map[string]resources.Quantity{"first": 10}))
 	// preemption alloc
-	if !node.CanAllocate(res, true) {
+	if !node.CanAllocate(res, true, false) {
 		t.Error("resource should have fitted in with preemption set")
 	}
 }

--- a/pkg/scheduler/partition.go
+++ b/pkg/scheduler/partition.go
@@ -545,21 +545,16 @@ func (pc *PartitionContext) GetNode(nodeID string) *objects.Node {
 // Get a copy of the nodes from the partition.
 // This list does not include reserved nodes or nodes marked unschedulable
 func (pc *PartitionContext) getSchedulableNodes() []*objects.Node {
-	return pc.getNodes(true)
+	return pc.getNodes()
 }
 
 // Get a copy of the nodes from the partition.
-// Excludes unschedulable nodes only, reserved node inclusion depends on the parameter passed in.
-func (pc *PartitionContext) getNodes(excludeReserved bool) []*objects.Node {
+func (pc *PartitionContext) getNodes() []*objects.Node {
 	pc.RLock()
 	defer pc.RUnlock()
 
 	nodes := make([]*objects.Node, 0)
 	for _, node := range pc.nodes {
-		// filter out the nodes that are not scheduling
-		if !node.IsSchedulable() || (excludeReserved && node.IsReserved()) {
-			continue
-		}
 		nodes = append(nodes, node)
 	}
 	return nodes
@@ -1144,7 +1139,7 @@ func (pc *PartitionContext) convertUGI(ugi *si.UserGroupInformation) (security.U
 //
 // NOTE: this is a lock free call. It must NOT be called holding the PartitionContext lock.
 func (pc *PartitionContext) calculateNodesResourceUsage() map[string][]int {
-	nodesCopy := pc.getNodes(false)
+	nodesCopy := pc.getNodes()
 	mapResult := make(map[string][]int)
 	for _, node := range nodesCopy {
 		for name, total := range node.GetCapacity().Resources {

--- a/pkg/scheduler/partition_test.go
+++ b/pkg/scheduler/partition_test.go
@@ -344,23 +344,7 @@ func TestGetNodes(t *testing.T) {
 
 	assert.Equal(t, 4, len(partition.nodes), "node list not correct length")
 	nodes = partition.getSchedulableNodes()
-	// returned list should be only two long
-	assert.Equal(t, 2, len(nodes), "node list not filtered")
-	// map iteration is random so don't know which we get first
-	for _, node = range nodes {
-		if node.NodeID != nodeID1 && node.NodeID != nodeID2 {
-			t.Fatalf("unexpected node returned in list: %s", node.NodeID)
-		}
-	}
-	nodes = partition.getNodes(false)
-	// returned list should be 3 long: no reserved filter
-	assert.Equal(t, 3, len(nodes), "node list was incorrectly filtered")
-	// check if we have all nodes: since there is a backing map we cannot have duplicates
-	for _, node = range nodes {
-		if node.NodeID == node3 {
-			t.Fatalf("unexpected node returned in list: %s", node.NodeID)
-		}
-	}
+	assert.Equal(t, 4, len(nodes), "node list not correct length")
 }
 
 func TestAddApp(t *testing.T) {


### PR DESCRIPTION
### What is this PR for?
leverage allocationTags to skip the schedulable and reserved node check, and retain the resource check.
Also remove the schedulable and reserved filter from `getnode` func

### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-758

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
