### PR TITLE
[YUNIKORN-193] Add option to allow parent to set unmanaged child queue …

### DIFF
--- a/pkg/common/configs/config.go
+++ b/pkg/common/configs/config.go
@@ -80,8 +80,9 @@ type QueueConfig struct {
 }
 
 type ChildTemplate struct {
-	Properties map[string]string `yaml:",omitempty" json:",omitempty"`
-	Resources  Resources         `yaml:",omitempty" json:",omitempty"`
+	MaxApplications uint64            `yaml:",omitempty" json:",omitempty"`
+	Properties      map[string]string `yaml:",omitempty" json:",omitempty"`
+	Resources       Resources         `yaml:",omitempty" json:",omitempty"`
 }
 
 // The resource limits to set on the queue. The definition allows for an unlimited number of types to be used.

--- a/pkg/common/configs/config.go
+++ b/pkg/common/configs/config.go
@@ -74,8 +74,14 @@ type QueueConfig struct {
 	Properties      map[string]string `yaml:",omitempty" json:",omitempty"`
 	AdminACL        string            `yaml:",omitempty" json:",omitempty"`
 	SubmitACL       string            `yaml:",omitempty" json:",omitempty"`
+	ChildTemplate   ChildTemplate     `yaml:",omitempty" json:",omitempty"`
 	Queues          []QueueConfig     `yaml:",omitempty" json:",omitempty"`
 	Limits          []Limit           `yaml:",omitempty" json:",omitempty"`
+}
+
+type ChildTemplate struct {
+	Properties map[string]string `yaml:",omitempty" json:",omitempty"`
+	Resources  Resources         `yaml:",omitempty" json:",omitempty"`
 }
 
 // The resource limits to set on the queue. The definition allows for an unlimited number of types to be used.

--- a/pkg/scheduler/objects/queue_test.go
+++ b/pkg/scheduler/objects/queue_test.go
@@ -1359,7 +1359,7 @@ func TestGetPartitionQueueDAOInfo(t *testing.T) {
 	root.template, err = template.FromConf(&configs.ChildTemplate{
 		Properties: getProperties(),
 		Resources: configs.Resources{
-			Max: getResourceConf(),
+			Max:        getResourceConf(),
 			Guaranteed: getResourceConf(),
 		},
 	})
@@ -1393,12 +1393,6 @@ func getZeroResourceConf() map[string]string {
 	resource["memory"] = "0"
 	resource["vcore"] = "0"
 	return resource
-}
-
-func getZeroResource(t *testing.T) *resources.Resource {
-	r, err := resources.NewResourceFromConf(getZeroResourceConf())
-	assert.NilError(t, err, "failed to parse resource: %v", err)
-	return r
 }
 
 func getProperties() map[string]string {
@@ -1496,7 +1490,7 @@ func TestLookupTemplate(t *testing.T) {
 	root.template, err = template.FromConf(&configs.ChildTemplate{
 		Properties: getProperties(),
 		Resources: configs.Resources{
-			Max: getResourceConf(),
+			Max:        getResourceConf(),
 			Guaranteed: getResourceConf(),
 		},
 	})
@@ -1513,7 +1507,7 @@ func TestLookupTemplate(t *testing.T) {
 	c1.template, err = template.FromConf(&configs.ChildTemplate{
 		Properties: getProperties(),
 		Resources: configs.Resources{
-			Max: getResourceConf(),
+			Max:        getResourceConf(),
 			Guaranteed: getResourceConf(),
 		},
 	})
@@ -1530,7 +1524,7 @@ func TestApplyTemplate(t *testing.T) {
 	childTemplate, err := template.FromConf(&configs.ChildTemplate{
 		Properties: getProperties(),
 		Resources: configs.Resources{
-			Max: getResourceConf(),
+			Max:        getResourceConf(),
 			Guaranteed: getResourceConf(),
 		},
 	})
@@ -1551,7 +1545,7 @@ func TestApplyTemplate(t *testing.T) {
 	zeroTemplate, err := template.FromConf(&configs.ChildTemplate{
 		Properties: getProperties(),
 		Resources: configs.Resources{
-			Max: getZeroResourceConf(),
+			Max:        getZeroResourceConf(),
 			Guaranteed: getZeroResourceConf(),
 		},
 	})
@@ -1565,15 +1559,15 @@ func TestApplyTemplate(t *testing.T) {
 func TestApplyConf(t *testing.T) {
 	conf := configs.QueueConfig{
 		SubmitACL: "",
-		AdminACL: "",
+		AdminACL:  "",
 		Resources: configs.Resources{
-			Max: getResourceConf(),
+			Max:        getResourceConf(),
 			Guaranteed: getResourceConf(),
 		},
-		ChildTemplate: configs.ChildTemplate {
+		ChildTemplate: configs.ChildTemplate{
 			Properties: make(map[string]string),
 			Resources: configs.Resources{
-				Max: getResourceConf(),
+				Max:        getResourceConf(),
 				Guaranteed: getResourceConf(),
 			},
 		},
@@ -1621,12 +1615,12 @@ func TestNewDynamicQueue(t *testing.T) {
 	parent.template, err = template.FromConf(&configs.ChildTemplate{
 		Properties: getProperties(),
 		Resources: configs.Resources{
-			Max: getResourceConf(),
+			Max:        getResourceConf(),
 			Guaranteed: getResourceConf(),
 		},
 	})
 	assert.NilError(t, err)
-	
+
 	// case 0: leaf can use template
 	childLeaf, err := NewDynamicQueue("leaf", true, parent)
 	assert.NilError(t, err, "failed to create dynamic queue: %v", err)

--- a/pkg/scheduler/objects/template/template.go
+++ b/pkg/scheduler/objects/template/template.go
@@ -1,0 +1,93 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package template
+
+import (
+	"github.com/apache/incubator-yunikorn-core/pkg/common/configs"
+	"github.com/apache/incubator-yunikorn-core/pkg/common/resources"
+	"github.com/apache/incubator-yunikorn-core/pkg/webservice/dao"
+)
+
+type Template struct {
+	properties         map[string]string
+	maxResource        *resources.Resource
+	guaranteedResource *resources.Resource
+}
+
+func FromConf(template *configs.ChildTemplate) (*Template, error) {
+	maxResource, err := resources.NewResourceFromConf(template.Resources.Max)
+	if err != nil {
+		return nil, err
+	}
+
+	guaranteedResource, err := resources.NewResourceFromConf(template.Resources.Guaranteed)
+	if err != nil {
+		return nil, err
+	}
+	return NewTemplate(template.Properties, maxResource, guaranteedResource), nil
+}
+
+func NewTemplate(properties map[string]string, maxResource *resources.Resource, guaranteedResource *resources.Resource) *Template {
+	template := &Template{
+		properties:         make(map[string]string),
+		maxResource:        maxResource.Clone(),
+		guaranteedResource: guaranteedResource.Clone(),
+	}
+	for k, v := range properties {
+		template.properties[k] = v
+	}
+	return template
+}
+
+// GetProperties returns a copy of properties. An empty map replaces the null value
+func (t *Template) GetProperties() map[string]string {
+	props := make(map[string]string)
+	for k, v := range t.properties {
+		props[k] = v
+	}
+	return props
+}
+
+// GetMaxResource returns a copy of max resource. it can be null
+func (t *Template) GetMaxResource() *resources.Resource {
+	if t == nil {
+		return nil
+	}
+	return t.maxResource.Clone()
+}
+
+// GetGuaranteedResource returns a copy of guaranteed resource. it can be null
+func (t *Template) GetGuaranteedResource() *resources.Resource {
+	if t == nil {
+		return nil
+	}
+	return t.guaranteedResource.Clone()
+}
+
+// GetTemplateInfo converts this to a TemplateInfo
+func (t *Template) GetTemplateInfo() *dao.TemplateInfo {
+	if t == nil {
+		return nil
+	}
+	return &dao.TemplateInfo{
+		Properties:         t.GetProperties(),
+		MaxResource:        t.maxResource.DAOString(),
+		GuaranteedResource: t.guaranteedResource.DAOString(),
+	}
+}

--- a/pkg/scheduler/objects/template/template_test.go
+++ b/pkg/scheduler/objects/template/template_test.go
@@ -1,0 +1,91 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package template
+
+import (
+	"reflect"
+	"strconv"
+	"testing"
+	"time"
+
+	"gotest.tools/assert"
+
+	"github.com/apache/incubator-yunikorn-core/pkg/common/configs"
+	"github.com/apache/incubator-yunikorn-core/pkg/common/resources"
+)
+
+func getResourceConf() map[string]string {
+	resource := make(map[string]string)
+	resource["memory"] = strconv.Itoa(time.Now().Second()%1000 + 10)
+	resource["vcore"] = strconv.Itoa(time.Now().Second()%1000 + 10)
+	return resource
+}
+
+func getProperties() map[string]string {
+	properties := make(map[string]string)
+	properties[strconv.Itoa(time.Now().Second()%1000)] = strconv.Itoa(time.Now().Second() % 1000)
+	return properties
+}
+
+func getResource(t *testing.T) *resources.Resource {
+	r, err := resources.NewResourceFromConf(getResourceConf())
+	assert.NilError(t, err, "failed to parse resource: %v", err)
+	return r
+}
+
+func checkMembers(t *testing.T, template *Template, properties map[string]string, maxResource *resources.Resource, guaranteedResource *resources.Resource) {
+	// test inner members
+	assert.Assert(t, reflect.DeepEqual(template.properties, properties))
+	assert.Assert(t, reflect.DeepEqual(template.maxResource, maxResource))
+	assert.Assert(t, reflect.DeepEqual(template.guaranteedResource, guaranteedResource))
+
+	// test all getters
+	assert.Assert(t, reflect.DeepEqual(template.GetProperties(), properties))
+	assert.Assert(t, reflect.DeepEqual(template.GetMaxResource(), maxResource))
+	assert.Assert(t, reflect.DeepEqual(template.GetGuaranteedResource(), guaranteedResource))
+}
+
+func TestNewTemplate(t *testing.T) {
+	properties := getProperties()
+	guaranteedResource := getResource(t)
+	maxResource := getResource(t)
+
+	checkMembers(t, NewTemplate(properties, maxResource, guaranteedResource), properties, maxResource, guaranteedResource)
+}
+
+func TestFromConf(t *testing.T) {
+	properties := getProperties()
+	guaranteedResourceConf := getResourceConf()
+	maxResourceConf := getResourceConf()
+
+	template, err := FromConf(&configs.ChildTemplate{
+		Properties: properties,
+		Resources: configs.Resources{
+			Max:        maxResourceConf,
+			Guaranteed: guaranteedResourceConf,
+		},
+	})
+	assert.NilError(t, err, "failed to create template: %v", err)
+
+	maxResource, err := resources.NewResourceFromConf(maxResourceConf)
+	assert.NilError(t, err, "failed to parse resource: %v", err)
+	guaranteedResource, err := resources.NewResourceFromConf(guaranteedResourceConf)
+	assert.NilError(t, err, "failed to parse resource: %v", err)
+	checkMembers(t, template, properties, maxResource, guaranteedResource)
+}

--- a/pkg/scheduler/objects/template/template_test.go
+++ b/pkg/scheduler/objects/template/template_test.go
@@ -66,7 +66,7 @@ func TestNewTemplate(t *testing.T) {
 	guaranteedResource := getResource(t)
 	maxResource := getResource(t)
 
-	checkMembers(t, NewTemplate(properties, maxResource, guaranteedResource), properties, maxResource, guaranteedResource)
+	checkMembers(t, newTemplate(properties, maxResource, guaranteedResource), properties, maxResource, guaranteedResource)
 }
 
 func TestFromConf(t *testing.T) {
@@ -74,6 +74,7 @@ func TestFromConf(t *testing.T) {
 	guaranteedResourceConf := getResourceConf()
 	maxResourceConf := getResourceConf()
 
+	// case 0: normal case
 	template, err := FromConf(&configs.ChildTemplate{
 		Properties: properties,
 		Resources: configs.Resources{
@@ -88,4 +89,45 @@ func TestFromConf(t *testing.T) {
 	guaranteedResource, err := resources.NewResourceFromConf(guaranteedResourceConf)
 	assert.NilError(t, err, "failed to parse resource: %v", err)
 	checkMembers(t, template, properties, maxResource, guaranteedResource)
+
+	// case 1: empty map produces nil template
+	empty0, err := FromConf(&configs.ChildTemplate{
+		Properties: make(map[string]string),
+		Resources: configs.Resources{
+			Max:        make(map[string]string),
+			Guaranteed: make(map[string]string),
+		},
+	})
+	assert.NilError(t, err)
+	assert.Assert(t, empty0 == nil)
+
+	empty1, err := FromConf(nil)
+	assert.NilError(t, err)
+	assert.Assert(t, empty1 == nil)
+
+	// case 2: empty key-value produces nil template
+	emptyProps := make(map[string]string)
+	emptyProps[""] = ""
+	empty2, err := FromConf(&configs.ChildTemplate{
+		Properties: emptyProps,
+		Resources: configs.Resources{
+			Max:        emptyProps,
+			Guaranteed: emptyProps,
+		},
+	})
+	assert.NilError(t, err)
+	assert.Assert(t, empty2 == nil)
+
+	// case 3: one item can produce template
+	props := make(map[string]string)
+	props["k"] = "v"
+	validTemplate, err := FromConf(&configs.ChildTemplate{
+		Properties: make(map[string]string),
+		Resources: configs.Resources{
+			Max:        getResourceConf(),
+			Guaranteed: make(map[string]string),
+		},
+	})
+	assert.NilError(t, err)
+	assert.Assert(t, validTemplate != nil)
 }

--- a/pkg/scheduler/partition.go
+++ b/pkg/scheduler/partition.go
@@ -180,7 +180,7 @@ func (pc *PartitionContext) updatePartitionDetails(conf configs.PartitionConfig)
 	queueConf := conf.Queues[0]
 	root := pc.root
 	// update the root queue
-	if err := root.SetQueueConfig(queueConf); err != nil {
+	if err := root.ApplyConf(queueConf); err != nil {
 		return err
 	}
 	root.UpdateSortType()
@@ -223,7 +223,7 @@ func (pc *PartitionContext) updateQueues(config []configs.QueueConfig, parent *o
 		if queue == nil {
 			queue, err = objects.NewConfiguredQueue(queueConfig, parent)
 		} else {
-			err = queue.SetQueueConfig(queueConfig)
+			err = queue.ApplyConf(queueConfig)
 		}
 		if err != nil {
 			return err
@@ -487,7 +487,7 @@ func (pc *PartitionContext) GetQueueInfos() dao.QueueDAOInfo {
 // Get the queue info for the whole queue structure to pass to the webservice
 func (pc *PartitionContext) GetPartitionQueues() dao.PartitionQueueDAOInfo {
 	var PartitionQueueDAOInfo = dao.PartitionQueueDAOInfo{}
-	PartitionQueueDAOInfo = pc.root.GetPartitionQueues()
+	PartitionQueueDAOInfo = pc.root.GetPartitionQueueDAOInfo()
 	PartitionQueueDAOInfo.Partition = pc.Name
 	return PartitionQueueDAOInfo
 }

--- a/pkg/scheduler/partition_test.go
+++ b/pkg/scheduler/partition_test.go
@@ -415,7 +415,7 @@ func TestAddAppTaskGroup(t *testing.T) {
 
 	// queue now has fair as sort policy app add should fail
 	queue := partition.GetQueue(defQueue)
-	err = queue.SetQueueConfig(configs.QueueConfig{
+	err = queue.ApplyConf(configs.QueueConfig{
 		Name:       "default",
 		Parent:     false,
 		Queues:     nil,
@@ -429,7 +429,7 @@ func TestAddAppTaskGroup(t *testing.T) {
 	}
 
 	// queue with stateaware as sort policy, with a max set smaller than placeholder ask: app add should fail
-	err = queue.SetQueueConfig(configs.QueueConfig{
+	err = queue.ApplyConf(configs.QueueConfig{
 		Name:       "default",
 		Parent:     false,
 		Queues:     nil,
@@ -444,7 +444,7 @@ func TestAddAppTaskGroup(t *testing.T) {
 	}
 
 	// queue with stateaware as sort policy, with a max set larger than placeholder ask: app add works
-	err = queue.SetQueueConfig(configs.QueueConfig{
+	err = queue.ApplyConf(configs.QueueConfig{
 		Name:      "default",
 		Parent:    false,
 		Queues:    nil,

--- a/pkg/webservice/dao/queue_info.go
+++ b/pkg/webservice/dao/queue_info.go
@@ -32,6 +32,12 @@ type QueueCapacity struct {
 	AbsUsedCapacity string `json:"absusedcapacity"`
 }
 
+type TemplateInfo struct {
+	MaxResource        string            `json:"maxResource"`
+	GuaranteedResource string            `json:"guaranteedResource"`
+	Properties         map[string]string `json:"properties"`
+}
+
 type PartitionQueueDAOInfo struct {
 	QueueName          string                  `json:"queuename"`
 	Status             string                  `json:"status"`
@@ -43,5 +49,6 @@ type PartitionQueueDAOInfo struct {
 	IsManaged          bool                    `json:"isManaged"`
 	Properties         map[string]string       `json:"properties"`
 	Parent             string                  `json:"parent"`
+	TemplateInfo       *TemplateInfo           `json:"Template"`
 	Children           []PartitionQueueDAOInfo `json:"children"`
 }

--- a/pkg/webservice/handlers_test.go
+++ b/pkg/webservice/handlers_test.go
@@ -131,6 +131,16 @@ partitions:
         name: root
         properties:
           application.sort.policy: stateaware
+        childtemplate:
+          properties:
+            application.sort.policy: stateaware
+          resources:
+            guaranteed:
+              memory: 400000
+              vcore: 40000
+            max:
+              memory: 600000
+              vcore: 60000
         queues: 
           - 
             name: a
@@ -925,6 +935,22 @@ func TestGetPartitionQueuesHandler(t *testing.T) {
 	assert.Equal(t, partitionQueuesDao.Children[2].Parent, "root")
 	assert.Equal(t, len(partitionQueuesDao.Properties), 1)
 	assert.Equal(t, partitionQueuesDao.Properties["application.sort.policy"], "stateaware")
+	assert.Equal(t, len(partitionQueuesDao.TemplateInfo.Properties), 1)
+	assert.Equal(t, partitionQueuesDao.TemplateInfo.Properties["application.sort.policy"], "stateaware")
+
+	maxResourcesConf := make(map[string]string)
+	maxResourcesConf["memory"] = "600000"
+	maxResourcesConf["vcore"] = "60000"
+	maxResource, err := resources.NewResourceFromConf(maxResourcesConf)
+	assert.NilError(t, err)
+	assert.Equal(t, partitionQueuesDao.TemplateInfo.MaxResource, maxResource.DAOString())
+
+	guaranteedResourcesConf := make(map[string]string)
+	guaranteedResourcesConf["memory"] = "400000"
+	guaranteedResourcesConf["vcore"] = "40000"
+	guaranteedResources, err := resources.NewResourceFromConf(guaranteedResourcesConf)
+	assert.NilError(t, err)
+	assert.Equal(t, partitionQueuesDao.TemplateInfo.GuaranteedResource, guaranteedResources.DAOString())
 
 	// Partition not sent as part of request
 	req, err = http.NewRequest("GET", "/ws/v1/partition/default/queues", strings.NewReader(""))

--- a/pkg/webservice/handlers_test.go
+++ b/pkg/webservice/handlers_test.go
@@ -137,10 +137,8 @@ partitions:
           resources:
             guaranteed:
               memory: 400000
-              vcore: 40000
             max:
               memory: 600000
-              vcore: 60000
         queues: 
           - 
             name: a
@@ -904,13 +902,6 @@ func TestMetricsNotEmpty(t *testing.T) {
 	assert.Assert(t, len(rr.Body.Bytes()) > 0, "Metrics response should not be empty")
 }
 
-func checkDAOString(t *testing.T, actual string, expected *resources.Resource) {
-	assert.Equal(t, len(actual), len(expected.DAOString()))
-	for k, v := range expected.Resources {
-		assert.Assert(t, strings.Contains(actual, fmt.Sprintf("%+v:%+v", k, v)))
-	}
-}
-
 func TestGetPartitionQueuesHandler(t *testing.T) {
 	configs.MockSchedulerConfigByData([]byte(configTwoLevelQueues))
 	var err error
@@ -947,17 +938,15 @@ func TestGetPartitionQueuesHandler(t *testing.T) {
 
 	maxResourcesConf := make(map[string]string)
 	maxResourcesConf["memory"] = "600000"
-	maxResourcesConf["vcore"] = "60000"
 	maxResource, err := resources.NewResourceFromConf(maxResourcesConf)
 	assert.NilError(t, err)
-	checkDAOString(t, partitionQueuesDao.TemplateInfo.MaxResource, maxResource)
+	assert.Equal(t, partitionQueuesDao.TemplateInfo.MaxResource, maxResource.DAOString())
 
 	guaranteedResourcesConf := make(map[string]string)
 	guaranteedResourcesConf["memory"] = "400000"
-	guaranteedResourcesConf["vcore"] = "40000"
 	guaranteedResources, err := resources.NewResourceFromConf(guaranteedResourcesConf)
 	assert.NilError(t, err)
-	checkDAOString(t, partitionQueuesDao.TemplateInfo.GuaranteedResource, guaranteedResources)
+	assert.Equal(t, partitionQueuesDao.TemplateInfo.GuaranteedResource, guaranteedResources.DAOString())
 
 	// Partition not sent as part of request
 	req, err = http.NewRequest("GET", "/ws/v1/partition/default/queues", strings.NewReader(""))

--- a/pkg/webservice/handlers_test.go
+++ b/pkg/webservice/handlers_test.go
@@ -904,6 +904,13 @@ func TestMetricsNotEmpty(t *testing.T) {
 	assert.Assert(t, len(rr.Body.Bytes()) > 0, "Metrics response should not be empty")
 }
 
+func checkDAOString(t *testing.T, actual string, expected *resources.Resource) {
+	assert.Equal(t, len(actual), len(expected.DAOString()))
+	for k, v := range expected.Resources {
+		assert.Assert(t, strings.Contains(actual, fmt.Sprintf("%+v:%+v", k, v)))
+	}
+}
+
 func TestGetPartitionQueuesHandler(t *testing.T) {
 	configs.MockSchedulerConfigByData([]byte(configTwoLevelQueues))
 	var err error
@@ -943,14 +950,14 @@ func TestGetPartitionQueuesHandler(t *testing.T) {
 	maxResourcesConf["vcore"] = "60000"
 	maxResource, err := resources.NewResourceFromConf(maxResourcesConf)
 	assert.NilError(t, err)
-	assert.Equal(t, partitionQueuesDao.TemplateInfo.MaxResource, maxResource.DAOString())
+	checkDAOString(t, partitionQueuesDao.TemplateInfo.MaxResource, maxResource)
 
 	guaranteedResourcesConf := make(map[string]string)
 	guaranteedResourcesConf["memory"] = "400000"
 	guaranteedResourcesConf["vcore"] = "40000"
 	guaranteedResources, err := resources.NewResourceFromConf(guaranteedResourcesConf)
 	assert.NilError(t, err)
-	assert.Equal(t, partitionQueuesDao.TemplateInfo.GuaranteedResource, guaranteedResources.DAOString())
+	checkDAOString(t, partitionQueuesDao.TemplateInfo.GuaranteedResource, guaranteedResources)
 
 	// Partition not sent as part of request
 	req, err = http.NewRequest("GET", "/ws/v1/partition/default/queues", strings.NewReader(""))


### PR DESCRIPTION
…properties

### What is this PR for?
The parent queue can not provide a template for auto generated child queues.
This means that there is no way for a parent to specify an application sorting policy or a maximum resource setting on a child queue.
application sort policy
max resources
We should allow a child template to be set on the managed parent queue (in the config) which can define the behaviour of leaf queues below it


### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [x] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-193

### How should this be tested?
this PR includes a lot of new unit tests

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
