### PR TITLE
[YUNIKORN-799] Fix NPE in application#GetQueueName

### DIFF
--- a/pkg/scheduler/context.go
+++ b/pkg/scheduler/context.go
@@ -481,7 +481,7 @@ func (cc *ClusterContext) processApplications(request *si.UpdateRequest) {
 			zap.String("applicationID", app.ApplicationID),
 			zap.String("partitionName", app.PartitionName),
 			zap.String("requested queue", app.QueueName),
-			zap.String("placed queue", schedApp.GetQueueName()))
+			zap.String("placed queue", schedApp.GetQueuePath()))
 	}
 
 	// Respond to RMProxy with accepted and rejected apps if needed

--- a/pkg/scheduler/objects/application.go
+++ b/pkg/scheduler/objects/application.go
@@ -1112,7 +1112,7 @@ func (sa *Application) tryNode(node *Node, ask *AllocationAsk) *Allocation {
 func (sa *Application) GetQueueName() string {
 	sa.RLock()
 	defer sa.RUnlock()
-	return sa.queue.QueuePath
+	return sa.QueueName
 }
 
 func (sa *Application) GetQueue() *Queue {

--- a/pkg/scheduler/objects/application.go
+++ b/pkg/scheduler/objects/application.go
@@ -55,7 +55,7 @@ const (
 type Application struct {
 	ApplicationID  string
 	Partition      string
-	QueueName      string
+	QueuePath      string
 	SubmissionTime time.Time
 
 	// Private fields need protection
@@ -87,7 +87,7 @@ func NewApplication(siApp *si.AddApplicationRequest, ugi security.UserGroup, eve
 	app := &Application{
 		ApplicationID:        siApp.ApplicationID,
 		Partition:            siApp.PartitionName,
-		QueueName:            siApp.QueueName,
+		QueuePath:            siApp.QueueName,
 		SubmissionTime:       time.Now(),
 		tags:                 siApp.Tags,
 		pending:              resources.NewResource(),
@@ -121,8 +121,8 @@ func (sa *Application) String() string {
 	if sa == nil {
 		return "application is nil"
 	}
-	return fmt.Sprintf("ApplicationID: %s, Partition: %s, QueueName: %s, SubmissionTime: %x, State: %s",
-		sa.ApplicationID, sa.Partition, sa.QueueName, sa.SubmissionTime, sa.stateMachine.Current())
+	return fmt.Sprintf("ApplicationID: %s, Partition: %s, QueuePath: %s, SubmissionTime: %x, State: %s",
+		sa.ApplicationID, sa.Partition, sa.QueuePath, sa.SubmissionTime, sa.stateMachine.Current())
 }
 
 func (sa *Application) SetState(state string) {
@@ -767,7 +767,7 @@ func (sa *Application) tryAllocate(headRoom *resources.Resource, nodeIterator fu
 		if !headRoom.FitInMaxUndef(request.AllocatedResource) {
 			// post scheduling events via the event plugin
 			if eventCache := events.GetEventCache(); eventCache != nil {
-				message := fmt.Sprintf("Application %s does not fit into %s queue", request.ApplicationID, sa.QueueName)
+				message := fmt.Sprintf("Application %s does not fit into %s queue", request.ApplicationID, sa.QueuePath)
 				if event, err := events.CreateRequestEventRecord(request.AllocationKey, request.ApplicationID, "InsufficientQueueResources", message); err != nil {
 					log.Logger().Warn("Event creation failed",
 						zap.String("event message", message),
@@ -1109,10 +1109,10 @@ func (sa *Application) tryNode(node *Node, ask *AllocationAsk) *Allocation {
 	return nil
 }
 
-func (sa *Application) GetQueueName() string {
+func (sa *Application) GetQueuePath() string {
 	sa.RLock()
 	defer sa.RUnlock()
-	return sa.QueueName
+	return sa.QueuePath
 }
 
 func (sa *Application) GetQueue() *Queue {
@@ -1123,17 +1123,17 @@ func (sa *Application) GetQueue() *Queue {
 
 // Set the leaf queue the application runs in. The queue will be created when the app is added to the partition.
 // The queue name is set to what the placement rule returned.
-func (sa *Application) SetQueueName(queuePath string) {
+func (sa *Application) SetQueuePath(queuePath string) {
 	sa.Lock()
 	defer sa.Unlock()
-	sa.QueueName = queuePath
+	sa.QueuePath = queuePath
 }
 
 // Set the leaf queue the application runs in.
 func (sa *Application) SetQueue(queue *Queue) {
 	sa.Lock()
 	defer sa.Unlock()
-	sa.QueueName = queue.QueuePath
+	sa.QueuePath = queue.QueuePath
 	sa.queue = queue
 }
 

--- a/pkg/scheduler/objects/application_test.go
+++ b/pkg/scheduler/objects/application_test.go
@@ -1172,3 +1172,15 @@ func TestGetAllRequests(t *testing.T) {
 	assert.Assert(t, len(app.getAllRequests()) == 1, "App should have only one request")
 	assert.Equal(t, app.getAllRequests()[0], ask, "Unexpected request found in the app")
 }
+
+func TestGetQueueNameAfterUnsetQueue(t *testing.T) {
+	app := newApplication(appID1, "default", "root.unknown")
+	assert.Equal(t, app.GetQueueName(), app.QueueName)
+	assert.Equal(t, app.GetQueueName(), "root.unknown")
+
+	// the queue is reset to nil but GetQueueName should work well
+	app.UnSetQueue()
+	assert.Assert(t, app.queue == nil)
+	assert.Equal(t, app.GetQueueName(), app.QueueName)
+	assert.Equal(t, app.GetQueueName(), "root.unknown")
+}

--- a/pkg/scheduler/objects/application_test.go
+++ b/pkg/scheduler/objects/application_test.go
@@ -43,7 +43,7 @@ func TestNewApplication(t *testing.T) {
 	siApp := &si.AddApplicationRequest{}
 	app := NewApplication(siApp, user, nil, "")
 	assert.Equal(t, app.ApplicationID, "", "application ID should not be set was not set in SI")
-	assert.Equal(t, app.QueueName, "", "queue name should not be set was not set in SI")
+	assert.Equal(t, app.QueuePath, "", "queue name should not be set was not set in SI")
 	assert.Equal(t, app.Partition, "", "partition name should not be set was not set in SI")
 	assert.Equal(t, app.rmID, "", "RM ID should not be set was not passed in")
 	assert.Equal(t, app.rmEventHandler, handler.EventHandler(nil), "event handler should be nil")
@@ -75,7 +75,7 @@ func TestNewApplication(t *testing.T) {
 	}
 	app = NewApplication(siApp, user, &appEventHandler{}, "myRM")
 	assert.Equal(t, app.ApplicationID, "appID", "application ID should not be set to SI value")
-	assert.Equal(t, app.QueueName, "some.queue", "queue name should not be set to SI value")
+	assert.Equal(t, app.QueuePath, "some.queue", "queue name should not be set to SI value")
 	assert.Equal(t, app.Partition, "AnotherPartition", "partition name should be set to SI value")
 	if app.rmEventHandler == nil {
 		t.Fatal("non nil handler was not set in the new app")
@@ -821,7 +821,7 @@ func TestQueueUpdate(t *testing.T) {
 	queue, err := createDynamicQueue(root, "test", false)
 	assert.NilError(t, err, "failed to create test queue")
 	app.SetQueue(queue)
-	assert.Equal(t, app.QueueName, "root.test")
+	assert.Equal(t, app.QueuePath, "root.test")
 }
 
 func TestStateTimeOut(t *testing.T) {
@@ -1175,12 +1175,12 @@ func TestGetAllRequests(t *testing.T) {
 
 func TestGetQueueNameAfterUnsetQueue(t *testing.T) {
 	app := newApplication(appID1, "default", "root.unknown")
-	assert.Equal(t, app.GetQueueName(), app.QueueName)
-	assert.Equal(t, app.GetQueueName(), "root.unknown")
+	assert.Equal(t, app.GetQueuePath(), app.QueuePath)
+	assert.Equal(t, app.GetQueuePath(), "root.unknown")
 
-	// the queue is reset to nil but GetQueueName should work well
+	// the queue is reset to nil but GetQueuePath should work well
 	app.UnSetQueue()
 	assert.Assert(t, app.queue == nil)
-	assert.Equal(t, app.GetQueueName(), app.QueueName)
-	assert.Equal(t, app.GetQueueName(), "root.unknown")
+	assert.Equal(t, app.GetQueuePath(), app.QueuePath)
+	assert.Equal(t, app.GetQueuePath(), "root.unknown")
 }

--- a/pkg/scheduler/objects/queue.go
+++ b/pkg/scheduler/objects/queue.go
@@ -1132,6 +1132,6 @@ func (sq *Queue) updateUsedResourceMetrics() {
 func (sq *Queue) String() string {
 	sq.RLock()
 	defer sq.RUnlock()
-	return fmt.Sprintf("{QueueName: %s, State: %s, StateTime: %x, MaxResource: %s}",
+	return fmt.Sprintf("{QueuePath: %s, State: %s, StateTime: %x, MaxResource: %s}",
 		sq.QueuePath, sq.stateMachine.Current(), sq.stateTime, sq.maxResource)
 }

--- a/pkg/scheduler/partition.go
+++ b/pkg/scheduler/partition.go
@@ -306,14 +306,14 @@ func (pc *PartitionContext) AddApplication(app *objects.Application) error {
 	}
 
 	// Put app under the queue
-	queueName := app.QueueName
+	queueName := app.QueuePath
 	pm := pc.getPlacementManager()
 	if pm.IsInitialised() {
 		err := pm.PlaceApplication(app)
 		if err != nil {
 			return fmt.Errorf("failed to place application %s: %v", appID, err)
 		}
-		queueName = app.QueueName
+		queueName = app.QueuePath
 		if queueName == "" {
 			return fmt.Errorf("application rejected by placement rules: %s", appID)
 		}
@@ -883,7 +883,7 @@ func (pc *PartitionContext) reserve(app *objects.Application, node *objects.Node
 
 	log.Logger().Info("allocation ask is reserved",
 		zap.String("appID", appID),
-		zap.String("queue", app.QueueName),
+		zap.String("queue", app.QueuePath),
 		zap.String("allocationKey", ask.AllocationKey),
 		zap.String("node", node.NodeID))
 }
@@ -912,7 +912,7 @@ func (pc *PartitionContext) unReserve(app *objects.Application, node *objects.No
 
 	log.Logger().Info("allocation ask is unreserved",
 		zap.String("appID", appID),
-		zap.String("queue", app.QueueName),
+		zap.String("queue", app.QueuePath),
 		zap.String("allocationKey", ask.AllocationKey),
 		zap.String("node", node.NodeID),
 		zap.Int("reservationsRemoved", num))

--- a/pkg/scheduler/partition_test.go
+++ b/pkg/scheduler/partition_test.go
@@ -1292,7 +1292,7 @@ func TestAddTGAppDynamic(t *testing.T) {
 	app := newApplicationTGTags(appID1, "default", "unknown", tgRes, tags)
 	err = partition.AddApplication(app)
 	assert.NilError(t, err, "app-1 should have been added to the partition")
-	assert.Equal(t, app.GetQueueName(), "root.unlimited", "app-1 not placed in expected queue")
+	assert.Equal(t, app.GetQueuePath(), "root.unlimited", "app-1 not placed in expected queue")
 
 	jsonRes := "{\"resources\":{\"first\":{\"value\":10}}}"
 	tags = map[string]string{"taskqueue": "same", objects.AppTagNamespaceResourceQuota: jsonRes}
@@ -1300,7 +1300,7 @@ func TestAddTGAppDynamic(t *testing.T) {
 	err = partition.AddApplication(app)
 	assert.NilError(t, err, "app-2 should have been added to the partition")
 	assert.Equal(t, partition.getApplication(appID2), app, "partition failed to add app incorrect app returned")
-	assert.Equal(t, app.GetQueueName(), "root.same", "app-2 not placed in expected queue")
+	assert.Equal(t, app.GetQueuePath(), "root.same", "app-2 not placed in expected queue")
 
 	jsonRes = "{\"resources\":{\"first\":{\"value\":1}}}"
 	tags = map[string]string{"taskqueue": "smaller", objects.AppTagNamespaceResourceQuota: jsonRes}

--- a/pkg/scheduler/placement/placement.go
+++ b/pkg/scheduler/placement/placement.go
@@ -150,7 +150,7 @@ func (m *AppPlacementManager) PlaceApplication(app *objects.Application) error {
 			log.Logger().Error("rule execution failed",
 				zap.String("ruleName", checkRule.getName()),
 				zap.Error(err))
-			app.QueueName = ""
+			app.QueuePath = ""
 			return err
 		}
 		// queueName returned make sure ACL allows access and create the queueName if not exist
@@ -206,10 +206,10 @@ func (m *AppPlacementManager) PlaceApplication(app *objects.Application) error {
 		zap.String("queueName", queueName))
 	// no more rules to check no queueName found reject placement
 	if queueName == "" {
-		app.QueueName = ""
+		app.QueuePath = ""
 		return fmt.Errorf("application rejected: no placment rule matched")
 	}
 	// Add the queue into the application, overriding what was submitted
-	app.SetQueueName(queueName)
+	app.SetQueuePath(queueName)
 	return nil
 }

--- a/pkg/scheduler/placement/placement_test.go
+++ b/pkg/scheduler/placement/placement_test.go
@@ -219,7 +219,7 @@ partitions:
 
 	// user rule existing queue, acl allowed
 	err = man.PlaceApplication(app)
-	queueName := app.QueueName
+	queueName := app.QueuePath
 	if err != nil || queueName != "root.testparent.testchild" {
 		t.Errorf("leaf exist: app should have been placed in user queue, queue: '%s', error: %v", queueName, err)
 	}
@@ -231,7 +231,7 @@ partitions:
 	// user rule new queue: fails on create flag
 	app = newApplication("app1", "default", "", user, tags, nil, "")
 	err = man.PlaceApplication(app)
-	queueName = app.QueueName
+	queueName = app.QueuePath
 	if err == nil || queueName != "" {
 		t.Errorf("leaf to create, no create flag: app should not have been placed, queue: '%s', error: %v", queueName, err)
 	}
@@ -239,7 +239,7 @@ partitions:
 	// provided rule (2nd rule): queue acl allowed, anyone create
 	app = newApplication("app1", "default", "root.fixed.leaf", user, tags, nil, "")
 	err = man.PlaceApplication(app)
-	queueName = app.QueueName
+	queueName = app.QueuePath
 	if err != nil || queueName != "root.fixed.leaf" {
 		t.Errorf("leave create, acl allow: app should have been placed, queue: '%s', error: %v", queueName, err)
 	}
@@ -251,7 +251,7 @@ partitions:
 	}
 	app = newApplication("app1", "default", "root.fixed.other", user, tags, nil, "")
 	err = man.PlaceApplication(app)
-	queueName = app.QueueName
+	queueName = app.QueuePath
 	if err == nil || queueName != "" {
 		t.Errorf("leaf to create, acl deny: app should not have been placed, queue: '%s', error: %v", queueName, err)
 	}
@@ -260,7 +260,7 @@ partitions:
 	tags = map[string]string{"namespace": "root.fixed.leaf"}
 	app = newApplication("app1", "default", "", user, tags, nil, "")
 	err = man.PlaceApplication(app)
-	queueName = app.QueueName
+	queueName = app.QueuePath
 	if err == nil || queueName != "" {
 		t.Errorf("existing leaf, acl deny: app should not have been placed, queue: '%s', error: %v", queueName, err)
 	}
@@ -272,7 +272,7 @@ partitions:
 	}
 	app = newApplication("app1", "default", "", user, tags, nil, "")
 	err = man.PlaceApplication(app)
-	queueName = app.QueueName
+	queueName = app.QueuePath
 	if err != nil || queueName != "root.fixed.leaf" {
 		t.Errorf("existing leaf, acl allow: app should have been placed, queue: '%s', error: %v", queueName, err)
 	}
@@ -280,7 +280,7 @@ partitions:
 	// provided rule (2nd): submit to parent
 	app = newApplication("app1", "default", "root.fixed", user, nil, nil, "")
 	err = man.PlaceApplication(app)
-	queueName = app.QueueName
+	queueName = app.QueuePath
 	if err == nil || queueName != "" {
 		t.Errorf("parent queue: app should not have been placed, queue: '%s', error: %v", queueName, err)
 	}

--- a/pkg/scheduler/placement/provided_rule.go
+++ b/pkg/scheduler/placement/provided_rule.go
@@ -53,7 +53,7 @@ func (pr *providedRule) initialise(conf configs.PlacementRule) error {
 
 func (pr *providedRule) placeApplication(app *objects.Application, queueFn func(string) *objects.Queue) (string, error) {
 	// since this is the provided rule we must have a queue in the info already
-	if app.QueueName == "" {
+	if app.QueuePath == "" {
 		return "", nil
 	}
 	// before anything run the filter
@@ -65,7 +65,7 @@ func (pr *providedRule) placeApplication(app *objects.Application, queueFn func(
 	}
 	var parentName string
 	var err error
-	queueName := app.QueueName
+	queueName := app.QueuePath
 	// if we have a fully qualified queue passed in do not run the parent rule
 	if !strings.HasPrefix(queueName, configs.RootQueue+configs.DOT) {
 		// run the parent rule if set

--- a/pkg/scheduler/placement/rule_test.go
+++ b/pkg/scheduler/placement/rule_test.go
@@ -73,12 +73,12 @@ func TestPlaceApp(t *testing.T) {
 		t.Errorf("test rule place application did not fail, err: %v, ", err)
 	}
 	// place application that should not fail and return the queue in the object
-	queue, err = nr.placeApplication(&objects.Application{QueueName: "passedin"}, nil)
+	queue, err = nr.placeApplication(&objects.Application{QueuePath: "passedin"}, nil)
 	if err != nil || queue != "passedin" {
 		t.Errorf("test rule place application did not fail, err: %v, ", err)
 	}
 	// place application that should not fail and return the queue in the object
-	queue, err = nr.placeApplication(&objects.Application{QueueName: "user.name"}, nil)
+	queue, err = nr.placeApplication(&objects.Application{QueuePath: "user.name"}, nil)
 	if err != nil || queue != "user_dot_name" {
 		t.Errorf("test rule place application did not fail, err: %v, ", err)
 	}

--- a/pkg/scheduler/placement/testrule.go
+++ b/pkg/scheduler/placement/testrule.go
@@ -51,8 +51,8 @@ func (tr *testRule) placeApplication(app *objects.Application, queueFn func(stri
 	if app == nil {
 		return "", fmt.Errorf("nil app passed in")
 	}
-	if app.QueueName != "" {
-		return replaceDot(app.QueueName), nil
+	if app.QueuePath != "" {
+		return replaceDot(app.QueuePath), nil
 	}
 	return "test", nil
 }

--- a/pkg/scheduler/tests/recovery_test.go
+++ b/pkg/scheduler/tests/recovery_test.go
@@ -649,7 +649,7 @@ partitions:
 		t.Fatal("application not found after recovery")
 	}
 	assert.Equal(t, app.ApplicationID, appID1)
-	assert.Equal(t, app.QueueName, "root.a")
+	assert.Equal(t, app.QueuePath, "root.a")
 }
 
 // test scheduler recovery that only registers apps

--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -111,8 +111,8 @@ func getClusterUtilization(w http.ResponseWriter, r *http.Request) {
 func getApplicationsInfo(w http.ResponseWriter, r *http.Request) {
 	writeHeaders(w)
 
-	queueName := r.URL.Query().Get("queue")
-	queueErr := validateQueue(queueName)
+	queuePath := r.URL.Query().Get("queue")
+	queueErr := validateQueue(queuePath)
 	if queueErr != nil {
 		buildJSONErrorResponse(w, queueErr.Error(), http.StatusBadRequest)
 		return
@@ -124,7 +124,7 @@ func getApplicationsInfo(w http.ResponseWriter, r *http.Request) {
 		appList := partition.GetApplications()
 		appList = append(appList, partition.GetCompletedApplications()...)
 		for _, app := range appList {
-			if len(queueName) == 0 || strings.EqualFold(queueName, app.GetQueueName()) {
+			if len(queuePath) == 0 || strings.EqualFold(queuePath, app.GetQueuePath()) {
 				appsDao = append(appsDao, getApplicationJSON(app))
 			}
 		}
@@ -135,14 +135,14 @@ func getApplicationsInfo(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func validateQueue(queueName string) error {
-	if queueName != "" {
-		queueNameArr := strings.Split(queueName, ".")
+func validateQueue(queuePath string) error {
+	if queuePath != "" {
+		queueNameArr := strings.Split(queuePath, ".")
 		for _, name := range queueNameArr {
 			if !configs.QueueNameRegExp.MatchString(name) {
 				return fmt.Errorf("problem in queue query parameter parsing as queue param "+
 					"%s contains invalid queue name %s. Queue name must only have "+
-					"alphanumeric characters, - or _, and be no longer than 64 characters", queueName, name)
+					"alphanumeric characters, - or _, and be no longer than 64 characters", queuePath, name)
 			}
 		}
 	}
@@ -306,7 +306,7 @@ func getApplicationJSON(app *objects.Application) *dao.ApplicationDAOInfo {
 		ApplicationID:  app.ApplicationID,
 		UsedResource:   app.GetAllocatedResource().DAOString(),
 		Partition:      app.Partition,
-		QueueName:      app.QueueName,
+		QueueName:      app.QueuePath,
 		SubmissionTime: app.SubmissionTime.UnixNano(),
 		Allocations:    allocationInfos,
 		State:          app.CurrentState(),


### PR DESCRIPTION
### What is this PR for?
the queue of application is reset to nil after application is completed. Hence, application#GetQueueName should return `QueueName` rather than `queue.QueuePath` to avoid NPE. Querying a cluster which has a completed application by REST API "/ws/v1/apps" can produce the NPE.


### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-799

### How should this be tested?
new unit test

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
