### PR TITLE
[YUNIKORN-800] ensure consistent response between /ws/v1/partition/{par…

### DIFF
--- a/pkg/scheduler/objects/queue.go
+++ b/pkg/scheduler/objects/queue.go
@@ -45,13 +45,14 @@ type Queue struct {
 	Name      string // Queue name as in the config etc.
 
 	// Private fields need protection
-	sortType     policies.SortPolicy     // How applications (leaf) or queues (parents) are sorted
-	children     map[string]*Queue       // Only for direct children, parent queue only
-	applications map[string]*Application // only for leaf queue
-	reservedApps map[string]int          // applications reserved within this queue, with reservation count
-	parent       *Queue                  // link back to the parent in the scheduler
-	preempting   *resources.Resource     // resource considered for preemption in the queue
-	pending      *resources.Resource     // pending resource for the apps in the queue
+	sortType              policies.SortPolicy     // How applications (leaf) or queues (parents) are sorted
+	children              map[string]*Queue       // Only for direct children, parent queue only
+	applications          map[string]*Application // only for leaf queue
+	completedApplications map[string]*Application // completed applications from this leaf queue
+	reservedApps          map[string]int          // applications reserved within this queue, with reservation count
+	parent                *Queue                  // link back to the parent in the scheduler
+	preempting            *resources.Resource     // resource considered for preemption in the queue
+	pending               *resources.Resource     // pending resource for the apps in the queue
 
 	// The queue properties should be treated as immutable the value is a merge of the
 	// parent properties with the config for this queue only manipulated during creation
@@ -72,14 +73,15 @@ type Queue struct {
 
 func newBlankQueue() *Queue {
 	return &Queue{
-		children:          make(map[string]*Queue),
-		applications:      make(map[string]*Application),
-		reservedApps:      make(map[string]int),
-		properties:        make(map[string]string),
-		stateMachine:      NewObjectState(),
-		allocatedResource: resources.NewResource(),
-		preempting:        resources.NewResource(),
-		pending:           resources.NewResource(),
+		children:              make(map[string]*Queue),
+		applications:          make(map[string]*Application),
+		completedApplications: make(map[string]*Application),
+		reservedApps:          make(map[string]int),
+		properties:            make(map[string]string),
+		stateMachine:          NewObjectState(),
+		allocatedResource:     resources.NewResource(),
+		preempting:            resources.NewResource(),
+		pending:               resources.NewResource(),
 	}
 }
 
@@ -544,14 +546,26 @@ func (sq *Queue) RemoveApplication(app *Application) {
 	defer sq.Unlock()
 
 	delete(sq.applications, appID)
+	sq.completedApplications[appID] = app
 }
 
-// Get a copy of all apps holding the lock
+// GetCopyOfApps Get a copy of all non-complated apps holding the lock
 func (sq *Queue) GetCopyOfApps() map[string]*Application {
 	sq.RLock()
 	defer sq.RUnlock()
-	appsCopy := make(map[string]*Application)
+	appsCopy := make(map[string]*Application, len(sq.applications))
 	for appID, app := range sq.applications {
+		appsCopy[appID] = app
+	}
+	return appsCopy
+}
+
+// GetCopyOfCompletedApps Get a copy of all completed apps holding the lock
+func (sq *Queue) GetCopyOfCompletedApps() map[string]*Application {
+	sq.RLock()
+	defer sq.RUnlock()
+	appsCopy := make(map[string]*Application, len(sq.completedApplications))
+	for appID, app := range sq.completedApplications {
 		appsCopy[appID] = app
 	}
 	return appsCopy

--- a/pkg/scheduler/objects/queue.go
+++ b/pkg/scheduler/objects/queue.go
@@ -564,11 +564,11 @@ func (sq *Queue) GetCopyOfApps() map[string]*Application {
 func (sq *Queue) GetCopyOfCompletedApps() map[string]*Application {
 	sq.RLock()
 	defer sq.RUnlock()
-	appsCopy := make(map[string]*Application, len(sq.completedApplications))
+	completedAppsCopy := make(map[string]*Application, len(sq.completedApplications))
 	for appID, app := range sq.completedApplications {
-		appsCopy[appID] = app
+		completedAppsCopy[appID] = app
 	}
-	return appsCopy
+	return completedAppsCopy
 }
 
 // Get a copy of the child queues

--- a/pkg/scheduler/objects/queue_test.go
+++ b/pkg/scheduler/objects/queue_test.go
@@ -324,7 +324,7 @@ func TestRemoveApplication(t *testing.T) {
 	assert.Assert(t, resources.IsZero(leaf.pending), "leaf queue pending resource not zero")
 	leaf.RemoveApplication(nonExist)
 	assert.Equal(t, len(leaf.applications), 1, "Non existing application was removed from the queue")
-	assert.Equal(t, len(leaf.GetCopyOfApps()), 1, "Application was not removed from the queue as expected")
+	assert.Equal(t, len(leaf.GetCopyOfApps()), 1, "Non existing application was removed from the queue")
 	assert.Equal(t, len(leaf.completedApplications), 0)
 	assert.Equal(t, len(leaf.GetCopyOfCompletedApps()), 0)
 	leaf.RemoveApplication(app)

--- a/pkg/scheduler/objects/queue_test.go
+++ b/pkg/scheduler/objects/queue_test.go
@@ -324,8 +324,14 @@ func TestRemoveApplication(t *testing.T) {
 	assert.Assert(t, resources.IsZero(leaf.pending), "leaf queue pending resource not zero")
 	leaf.RemoveApplication(nonExist)
 	assert.Equal(t, len(leaf.applications), 1, "Non existing application was removed from the queue")
+	assert.Equal(t, len(leaf.GetCopyOfApps()), 1, "Application was not removed from the queue as expected")
+	assert.Equal(t, len(leaf.completedApplications), 0)
+	assert.Equal(t, len(leaf.GetCopyOfCompletedApps()), 0)
 	leaf.RemoveApplication(app)
 	assert.Equal(t, len(leaf.applications), 0, "Application was not removed from the queue as expected")
+	assert.Equal(t, len(leaf.GetCopyOfApps()), 0, "Application was not removed from the queue as expected")
+	assert.Equal(t, len(leaf.completedApplications), 1)
+	assert.Equal(t, len(leaf.GetCopyOfCompletedApps()), 1)
 
 	// try the same again now with pending resources set
 	res := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 10})

--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -701,8 +701,12 @@ func getQueueApplications(w http.ResponseWriter, r *http.Request) {
 	}
 
 	apps := queue.GetCopyOfApps()
-	appsDao := make([]*dao.ApplicationDAOInfo, 0, len(apps))
+	completedApps := queue.GetCopyOfCompletedApps()
+	appsDao := make([]*dao.ApplicationDAOInfo, 0, len(apps)+len(completedApps))
 	for _, app := range apps {
+		appsDao = append(appsDao, getApplicationJSON(app))
+	}
+	for _, app := range completedApps {
 		appsDao = append(appsDao, getApplicationJSON(app))
 	}
 


### PR DESCRIPTION
…titioName}/queue/{queueName}/applications and /ws/v1/apps

### What is this PR for?
In contrast to /ws/v1/apps, the response of /ws/v1/partition/{partitioName}/queue/{queueName}/applications excludes the completed applications.


### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-800

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
