### PR TITLE
[YUNIKORN-817] Avoid NPE in /ws/v1/nodes/utilization REST API when partition has no node

### DIFF
--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -178,6 +178,7 @@ func getNodesUtilization(w http.ResponseWriter, r *http.Request) {
 	var result []*dao.NodesUtilDAOInfo
 	for _, partition := range lists {
 		partitionResource := partition.GetTotalPartitionResource()
+		// partitionResource can be null if the partition has no node
 		if partitionResource != nil {
 			for name := range partitionResource.Resources {
 				result = append(result, getNodesUtilJSON(partition, name))

--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -177,9 +177,11 @@ func getNodesUtilization(w http.ResponseWriter, r *http.Request) {
 	lists := schedulerContext.GetPartitionMapClone()
 	var result []*dao.NodesUtilDAOInfo
 	for _, partition := range lists {
-		for name := range partition.GetTotalPartitionResource().Resources {
-			nodesUtil := getNodesUtilJSON(partition, name)
-			result = append(result, nodesUtil)
+		partitionResource := partition.GetTotalPartitionResource()
+		if partitionResource != nil {
+			for name := range partitionResource.Resources {
+				result = append(result, getNodesUtilJSON(partition, name))
+			}
 		}
 	}
 	if err := json.NewEncoder(w).Encode(result); err != nil {

--- a/pkg/webservice/handlers_test.go
+++ b/pkg/webservice/handlers_test.go
@@ -1182,3 +1182,23 @@ func TestValidateQueue(t *testing.T) {
 	err2 := validateQueue("root")
 	assert.NilError(t, err2, "Queue path is correct but stil throwing error.")
 }
+
+func TestGetNodesUtilization(t *testing.T) {
+	configs.MockSchedulerConfigByData([]byte(configMultiPartitions))
+	var err error
+	schedulerContext, err = scheduler.NewClusterContext(rmID, policyGroup)
+	assert.NilError(t, err)
+	assert.Equal(t, 2, len(schedulerContext.GetPartitionMapClone()))
+
+	var req *http.Request
+	req, err = http.NewRequest("GET", "/ws/v1/nodes/utilization", strings.NewReader(""))
+	req = mux.SetURLVars(req, make(map[string]string))
+	assert.NilError(t, err)
+	resp := &MockResponseWriter{}
+	var nodesDao []*dao.NodesUtilDAOInfo
+	// all partitions have no nodes, but it should be fine to get utilization
+	getNodesUtilization(resp, req)
+	err = json.Unmarshal(resp.outputBytes, &nodesDao)
+	assert.NilError(t, err)
+	assert.Equal(t, len(nodesDao), 0)
+}


### PR DESCRIPTION
… no node

### What is this PR for?
`PartitionContext#totalPartitionResource` is null if the partition has no node. We need to check null before converting it to dao object. 


### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-817

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
