### PR TITLE
[YUNIKORN-813] The capacity of undefined resource should NOT be consi…

### DIFF
--- a/pkg/scheduler/objects/queue.go
+++ b/pkg/scheduler/objects/queue.go
@@ -910,12 +910,31 @@ func (sq *Queue) internalHeadRoom(parentHeadRoom *resources.Resource) *resources
 	if headRoom == nil {
 		return parentHeadRoom
 	}
+
+	// we will replace all incorrect values, which are caused by undefined resources, by resources of parent headroom after headRoom
+	// get the unused resources by calling SubFrom
+	undefinedResources := make(map[string]resources.Quantity)
+	if parentHeadRoom != nil {
+		for k, v := range parentHeadRoom.Resources {
+			if _, ok := headRoom.Resources[k]; !ok {
+				undefinedResources[k] = v
+			}
+		}
+	}
+
 	// calculate unused
 	headRoom.SubFrom(sq.allocatedResource)
+
 	// check the minimum of the two: parentHeadRoom is nil for root
 	if parentHeadRoom == nil {
 		return headRoom
 	}
+
+	// replace the incorrect result by resources of parent headroom
+	for k, v := range undefinedResources {
+		headRoom.Resources[k] = v
+	}
+
 	return resources.ComponentWiseMin(headRoom, parentHeadRoom)
 }
 


### PR DESCRIPTION
…dered zero

### What is this PR for?
```yaml
  resources:
    max:
      memory: 10000
```
If above configuration is added to a leaf queue, the queue can't run any application since the "vcore" is assumed to be zero. That obstructs us from limiting only a part of resources.  It seems to me the undefined resource should be referenced to parent's resource.


### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Update the docs of quota - it supports to define quota with either only vcore or only memory

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-813

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
