### PR TITLE
[YUNIKORN-831] node sorting should check other resources of nodes instead of comparing node id directly

### DIFF
--- a/pkg/common/resources/resources.go
+++ b/pkg/common/resources/resources.go
@@ -439,6 +439,12 @@ func (r *Resource) fitIn(smaller *Resource, skipUndef bool) bool {
 	return true
 }
 
+// GetShares return an array consisting of value of each resource quantity
+// the result is sort by increasing order
+func GetShares(res *Resource) []float64 {
+	return getShares(res, nil)
+}
+
 // Get the share of each resource quantity when compared to the total
 // resources quantity
 // NOTE: shares can be negative and positive in the current assumptions
@@ -495,7 +501,7 @@ func CompUsageRatio(left, right, total *Resource) int {
 	lshares := getShares(left, total)
 	rshares := getShares(right, total)
 
-	return compareShares(lshares, rshares)
+	return CompareShares(lshares, rshares)
 }
 
 // Calculate share for left of total and right of total separately.
@@ -507,7 +513,7 @@ func CompUsageRatioSeparately(left, leftTotal, right, rightTotal *Resource) int 
 	lshares := getShares(left, leftTotal)
 	rshares := getShares(right, rightTotal)
 
-	return compareShares(lshares, rshares)
+	return CompareShares(lshares, rshares)
 }
 
 // Compare two resources usage shares and assumes a nil total resource.
@@ -520,17 +526,7 @@ func CompUsageShares(left, right *Resource) int {
 	lshares := getShares(left, nil)
 	rshares := getShares(right, nil)
 
-	return compareShares(lshares, rshares)
-}
-
-// Get largest usage share as a float64.
-func LargestUsageShare(resource *Resource) float64 {
-	shares := getShares(resource, nil)
-	share := float64(0)
-	if shareLen := len(shares); shareLen != 0 {
-		share = shares[shareLen-1]
-	}
-	return share
+	return CompareShares(lshares, rshares)
 }
 
 // Get fairness ratio calculated by:
@@ -563,7 +559,7 @@ func FairnessRatio(left, right, total *Resource) float64 {
 // 0 for equal shares
 // 1 if the left share is larger
 // -1 if the right share is larger
-func compareShares(lshares, rshares []float64) int {
+func CompareShares(lshares, rshares []float64) int {
 	// get the length of the shares: a nil or empty share list gives -1
 	lIdx := len(lshares) - 1
 	rIdx := len(rshares) - 1

--- a/pkg/common/resources/resources_test.go
+++ b/pkg/common/resources/resources_test.go
@@ -1115,31 +1115,31 @@ func TestGetShares(t *testing.T) {
 
 func TestCompareShares(t *testing.T) {
 	// simple cases nil or empty shares
-	comp := compareShares(nil, nil)
+	comp := CompareShares(nil, nil)
 	if comp != 0 {
 		t.Error("nil shares not equal")
 	}
 	left := make([]float64, 0)
 	right := make([]float64, 0)
-	comp = compareShares(left, right)
+	comp = CompareShares(left, right)
 	if comp != 0 {
 		t.Error("empty shares not equal")
 	}
 	// simple case same shares
 	left = []float64{0, 5}
-	comp = compareShares(left, left)
+	comp = CompareShares(left, left)
 	if comp != 0 {
 		t.Error("same shares are not equal")
 	}
 	// highest same, less shares on one side, zero values
 	left = []float64{0, 10.0}
 	right = []float64{10.0}
-	comp = compareShares(left, right)
+	comp = CompareShares(left, right)
 	if comp != 0 {
 		t.Error("same shares are not equal")
 	}
 	left, right = right, left
-	comp = compareShares(left, right)
+	comp = CompareShares(left, right)
 	if comp != 0 {
 		t.Error("same shares are not equal")
 	}
@@ -1147,12 +1147,12 @@ func TestCompareShares(t *testing.T) {
 	// highest is same, less shares on one side, positive values
 	left = []float64{1, 10}
 	right = []float64{10}
-	comp = compareShares(left, right)
+	comp = CompareShares(left, right)
 	if comp != 1 {
 		t.Errorf("left should have been larger: left %v, right %v", left, right)
 	}
 	left, right = right, left
-	comp = compareShares(left, right)
+	comp = CompareShares(left, right)
 	if comp != -1 {
 		t.Errorf("right should have been larger: left %v, right %v", left, right)
 	}
@@ -1160,12 +1160,12 @@ func TestCompareShares(t *testing.T) {
 	// highest is same, less shares on one side, negative values
 	left = []float64{-10, 10}
 	right = []float64{10}
-	comp = compareShares(left, right)
+	comp = CompareShares(left, right)
 	if comp != -1 {
 		t.Errorf("left should have been smaller: left %v, right %v", left, right)
 	}
 	left, right = right, left
-	comp = compareShares(left, right)
+	comp = CompareShares(left, right)
 	if comp != 1 {
 		t.Errorf("right should have been smaller: left %v, right %v", left, right)
 	}
@@ -1173,12 +1173,12 @@ func TestCompareShares(t *testing.T) {
 	// highest is smaller, less shares on one side, values are not important
 	left = []float64{0, 10}
 	right = []float64{5}
-	comp = compareShares(left, right)
+	comp = CompareShares(left, right)
 	if comp != 1 {
 		t.Errorf("left should have been larger: left %v, right %v", left, right)
 	}
 	left, right = right, left
-	comp = compareShares(left, right)
+	comp = CompareShares(left, right)
 	if comp != -1 {
 		t.Errorf("right should have been larger: left %v, right %v", left, right)
 	}
@@ -1186,12 +1186,12 @@ func TestCompareShares(t *testing.T) {
 	// highest is +Inf, less shares on one side, zeros before -Inf value
 	left = []float64{math.Inf(-1), 0, 0, math.Inf(1)}
 	right = []float64{math.Inf(1)}
-	comp = compareShares(left, right)
+	comp = CompareShares(left, right)
 	if comp != -1 {
 		t.Errorf("left should have been smaller: left %v, right %v", left, right)
 	}
 	left, right = right, left
-	comp = compareShares(left, right)
+	comp = CompareShares(left, right)
 	if comp != 1 {
 		t.Errorf("right should have been smaller: left %v, right %v", left, right)
 	}
@@ -1199,12 +1199,12 @@ func TestCompareShares(t *testing.T) {
 	// longer list of values (does not cover any new case)
 	left = []float64{-100, -10, 0, 1.1, 2.2, 3.3, 5, math.Inf(1)}
 	right = []float64{-99.99, -10, 0, 1.1, 2.2, 3.3, 5, math.Inf(1)}
-	comp = compareShares(left, right)
+	comp = CompareShares(left, right)
 	if comp != -1 {
 		t.Errorf("left should have been smaller: left %v, right %v", left, right)
 	}
 	left, right = right, left
-	comp = compareShares(left, right)
+	comp = CompareShares(left, right)
 	if comp != 1 {
 		t.Errorf("right should have been smaller: left %v, right %v", left, right)
 	}

--- a/pkg/scheduler/objects/nodesorting.go
+++ b/pkg/scheduler/objects/nodesorting.go
@@ -28,7 +28,7 @@ import (
 
 type NodeSortingPolicy interface {
 	PolicyType() policies.SortingPolicy
-	ScoreNode(node *Node) float64
+	ScoreNode(node *Node) []float64
 }
 
 type binPackingNodeSortingPolicy struct{}
@@ -42,14 +42,19 @@ func (fairnessNodeSortingPolicy) PolicyType() policies.SortingPolicy {
 	return policies.FairnessPolicy
 }
 
-func (binPackingNodeSortingPolicy) ScoreNode(node *Node) float64 {
+func (binPackingNodeSortingPolicy) ScoreNode(node *Node) []float64 {
 	// choose most loaded node first
-	return resources.LargestUsageShare(node.GetAvailableResource())
+	return resources.GetShares(node.GetAvailableResource())
 }
 
-func (fairnessNodeSortingPolicy) ScoreNode(node *Node) float64 {
+func (fairnessNodeSortingPolicy) ScoreNode(node *Node) []float64 {
 	// choose least loaded node first
-	return -resources.LargestUsageShare(node.GetAvailableResource())
+	result := resources.GetShares(node.GetAvailableResource())
+	reverse := make([]float64, 0, len(result))
+	for _, v := range result {
+		reverse = append(reverse, -v)
+	}
+	return reverse
 }
 
 func NewNodeSortingPolicy(policyType string) NodeSortingPolicy {

--- a/pkg/scheduler/objects/sorters_test.go
+++ b/pkg/scheduler/objects/sorters_test.go
@@ -418,6 +418,6 @@ func sortNodes(nodes []*Node, sortType NodeSortingPolicy) {
 	sort.SliceStable(nodes, func(i, j int) bool {
 		l := nodes[i]
 		r := nodes[j]
-		return sortType.ScoreNode(l) < sortType.ScoreNode(r)
+		return resources.CompareShares(sortType.ScoreNode(l), sortType.ScoreNode(r)) < 0
 	})
 }


### PR DESCRIPTION
…tead of comparing node id directly

### What is this PR for?
Node sorting scores node according to `resources.LargestUsageShare`. However, the largest usage in our cluster is always storage (and all nodes have same storage capacity). It results in the order is always based on `node id`. Before this patch, the order will compare remaining "usage" (vcore, memory, etc) when largest usage is equal.


### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-831

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
