### PR TITLE
[YUNIKORN-832] Updating config can't remove partition

### DIFF
--- a/pkg/scheduler/context.go
+++ b/pkg/scheduler/context.go
@@ -239,7 +239,7 @@ func (cc *ClusterContext) removePartitionsByRMID(event *rmevent.RMPartitionsRemo
 	// Just remove corresponding partitions
 	for k, partition := range cc.partitions {
 		if partition.RmID == event.RmID {
-			partition.partitionManager.stop = true
+			partition.partitionManager.Stop()
 			partitionToRemove[k] = true
 		}
 	}

--- a/pkg/scheduler/partition.go
+++ b/pkg/scheduler/partition.go
@@ -91,10 +91,7 @@ func newPartitionContext(conf configs.PartitionConfig, rmID string, cc *ClusterC
 		reservedApps:          make(map[string]int),
 		nodes:                 objects.NewNodeCollection(conf.Name),
 	}
-	pc.partitionManager = &partitionManager{
-		pc: pc,
-		cc: cc,
-	}
+	pc.partitionManager = newPartitionManager(pc, cc)
 	if err := pc.initialPartitionFromConfig(conf); err != nil {
 		return nil, err
 	}

--- a/pkg/scheduler/partition_manager_test.go
+++ b/pkg/scheduler/partition_manager_test.go
@@ -1,0 +1,98 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"testing"
+
+	"gotest.tools/assert"
+
+	"github.com/apache/incubator-yunikorn-core/pkg/common/configs"
+	"github.com/apache/incubator-yunikorn-core/pkg/common/security"
+	"github.com/apache/incubator-yunikorn-core/pkg/scheduler/objects"
+)
+
+func createPartitionContext(t *testing.T) *PartitionContext {
+	conf := configs.PartitionConfig{
+		Name: "test",
+		Queues: []configs.QueueConfig{
+			{
+				Name:      "root",
+				Parent:    true,
+				SubmitACL: "*",
+				Queues:    nil,
+			},
+		},
+	}
+	cc := &ClusterContext{}
+	partition, err := newPartitionContext(conf, "test", cc)
+	assert.NilError(t, err)
+	return partition
+}
+
+func TestStopPartitionManager(t *testing.T) {
+	p := createPartitionContext(t)
+
+	p.partitionManager.Stop()
+
+	// this call should not be blocked forever
+	p.partitionManager.cleanExpiredApps()
+
+	// this call should not be blocked forever
+	p.partitionManager.cleanRoot()
+}
+
+func TestCleanQueues(t *testing.T) {
+	p := createPartitionContext(t)
+
+	root := p.GetQueue("root")
+	assert.Assert(t, root != nil)
+
+	// add new queue to partition
+	queue, err := p.createQueue("root.test", security.UserGroup{})
+	assert.NilError(t, err)
+	assert.Equal(t, false, queue.IsManaged())
+	assert.Equal(t, 1, len(p.root.GetCopyOfChildren()))
+
+	// make sure all queues are removed
+	p.partitionManager.cleanQueues(p.root)
+	assert.Equal(t, 0, len(p.root.GetCopyOfChildren()))
+}
+
+func TestRemoveAll(t *testing.T) {
+	p := createPartitionContext(t)
+
+	_, err := p.createQueue("root.test", security.UserGroup{})
+	assert.NilError(t, err)
+
+	// add new node to partition
+	err = p.addNodeToList(&objects.Node{})
+	assert.NilError(t, err)
+	assert.Equal(t, 1, p.nodes.GetNodeCount())
+
+	// add new application to partition
+	err = p.AddApplication(newApplication("app", p.Name, "root.test"))
+	assert.NilError(t, err)
+	assert.Equal(t, 1, len(p.applications))
+
+	// make sure all nodes and applications are removed
+	p.partitionManager.remove()
+	assert.Equal(t, 0, len(p.applications))
+	assert.Equal(t, 0, p.nodes.GetNodeCount())
+}


### PR DESCRIPTION
### What is this PR for?
All functions in `partition_manager` are using pass-by-value so setting the `stop` flag to true can't terminate other threads.

```
func (manager partitionManager) Stop() {
 manager.stop = true
}
```

Also, the thread used to cleanup expired app can't be stopped quickly after removing partition because it needs to sleep for 24 hours.

```
func (manager partitionManager) cleanupExpiredApps() {
	for {
		if manager.stop {
			break
		}
		manager.pc.cleanupExpiredApps()
		time.Sleep(appRemovalInterval)
	}
}
```


### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-832

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
