### PR TITLE
[YUNIKORN-847] Use resource weighting for node sorting.

### DIFF
--- a/pkg/common/configs/config.go
+++ b/pkg/common/configs/config.go
@@ -143,7 +143,8 @@ type Limit struct {
 // Global Node Sorting Policy section
 // - type: different type of policies supported (binpacking, fair etc)
 type NodeSortingPolicy struct {
-	Type string
+	Type            string
+	ResourceWeights map[string]float64 `yaml:",omitempty" json:",omitempty"`
 }
 
 type LoadSchedulerConfigFunc func(policyGroup string) (*SchedulerConfig, error)

--- a/pkg/common/configs/configvalidator.go
+++ b/pkg/common/configs/configvalidator.go
@@ -259,8 +259,17 @@ func checkNodeSortingPolicy(partition *PartitionConfig) error {
 
 	// Defined polices.
 	_, err := policies.SortingPolicyFromString(policy.Type)
+	if err != nil {
+		return err
+	}
 
-	return err
+	for k, v := range policy.ResourceWeights {
+		if v < float64(0) {
+			return fmt.Errorf("negative resource weight for %s is not allowed", k)
+		}
+	}
+
+	return nil
 }
 
 // Check the queue names configured for compliance and uniqueness

--- a/pkg/common/resources/resources.go
+++ b/pkg/common/resources/resources.go
@@ -523,16 +523,6 @@ func CompUsageShares(left, right *Resource) int {
 	return compareShares(lshares, rshares)
 }
 
-// Get largest usage share as a float64.
-func LargestUsageShare(resource *Resource) float64 {
-	shares := getShares(resource, nil)
-	share := float64(0)
-	if shareLen := len(shares); shareLen != 0 {
-		share = shares[shareLen-1]
-	}
-	return share
-}
-
 // Get fairness ratio calculated by:
 // highest share for left resource from total divided by
 // highest share for right resource from total.

--- a/pkg/scheduler/objects/node.go
+++ b/pkg/scheduler/objects/node.go
@@ -552,6 +552,22 @@ func (sn *Node) UnReserveApps() ([]string, []int) {
 	return appReserve, askRelease
 }
 
+// Gets map of name -> resource usages per type in shares (0 to 1). Can return NaN.
+func (sn *Node) GetResourceUsageShares() map[string]float64 {
+	sn.RLock()
+	defer sn.RUnlock()
+	res := make(map[string]float64)
+	used := resources.Add(sn.allocatedResource, sn.occupiedResource)
+	if sn.totalResource == nil {
+		// no resources present, so no usage
+		return res
+	}
+	for k, v := range sn.totalResource.Resources {
+		res[k] = float64(used.Resources[k]) / float64(v)
+	}
+	return res
+}
+
 func (sn *Node) AddListener(listener NodeListener) {
 	sn.Lock()
 	defer sn.Unlock()

--- a/pkg/scheduler/objects/node.go
+++ b/pkg/scheduler/objects/node.go
@@ -557,13 +557,12 @@ func (sn *Node) GetResourceUsageShares() map[string]float64 {
 	sn.RLock()
 	defer sn.RUnlock()
 	res := make(map[string]float64)
-	used := resources.Add(sn.allocatedResource, sn.occupiedResource)
 	if sn.totalResource == nil {
 		// no resources present, so no usage
 		return res
 	}
 	for k, v := range sn.totalResource.Resources {
-		res[k] = float64(used.Resources[k]) / float64(v)
+		res[k] = float64(1) - (float64(sn.availableResource.Resources[k]) / float64(v))
 	}
 	return res
 }

--- a/pkg/scheduler/objects/nodesorting_test.go
+++ b/pkg/scheduler/objects/nodesorting_test.go
@@ -82,8 +82,26 @@ partitions:
 	assert.Equal(t, policy.resourceWeights["memory"], 1.0, "Wrong weight for memory")
 }
 
+func TestInvalidResourceWeightsFromConfig(t *testing.T) {
+	badConf := `
+partitions:
+  - name: default
+    nodesortpolicy:
+      type: fair
+      resourceweights:
+        vcore: -1.0
+        memory: 0.5
+        gpu: 5.0
+    queues:
+      - name: root
+        submitacl: '*'
+`
+	_, err := configs.LoadSchedulerConfigFromByteArray([]byte(badConf))
+	assert.ErrorContains(t, err, "negative", "Expected error")
+}
+
 func TestSpecifiedResourceWeightsFromConfig(t *testing.T) {
-	emptyConf := `
+	explicitConf := `
 partitions:
   - name: default
     nodesortpolicy:
@@ -96,7 +114,7 @@ partitions:
       - name: root
         submitacl: '*'
 `
-	conf, err := configs.LoadSchedulerConfigFromByteArray([]byte(emptyConf))
+	conf, err := configs.LoadSchedulerConfigFromByteArray([]byte(explicitConf))
 	assert.NilError(t, err, "No error is expected")
 	if conf == nil {
 		t.Fatal("Returned conf was nil")

--- a/pkg/scheduler/objects/nodesorting_test.go
+++ b/pkg/scheduler/objects/nodesorting_test.go
@@ -21,6 +21,11 @@ package objects
 import (
 	"testing"
 
+	"github.com/google/uuid"
+	"gotest.tools/assert"
+
+	"github.com/apache/incubator-yunikorn-core/pkg/common/configs"
+	"github.com/apache/incubator-yunikorn-core/pkg/common/resources"
 	"github.com/apache/incubator-yunikorn-core/pkg/scheduler/policies"
 )
 
@@ -36,9 +41,227 @@ func TestNewNodeSortingPolicy(t *testing.T) {
 		{"UnknownString", "unknown", policies.FairnessPolicy},
 	}
 	for _, tt := range tests {
-		got := NewNodeSortingPolicy(tt.arg)
+		got := NewNodeSortingPolicy(tt.arg, nil)
 		if got == nil || got.PolicyType() != tt.want {
 			t.Errorf("%s unexpected policy returned, expected = '%s', got '%v'", tt.name, tt.want, got)
 		}
 	}
+}
+
+func TestEmptyResourceWeightsFromConfig(t *testing.T) {
+	emptyConf := `
+partitions:
+  - name: default
+    nodesortpolicy:
+      type: fair
+    queues:
+      - name: root
+        submitacl: '*'
+`
+	conf, err := configs.LoadSchedulerConfigFromByteArray([]byte(emptyConf))
+	assert.NilError(t, err, "No error is expected")
+	if conf == nil {
+		t.Fatal("Returned conf was nil")
+	}
+	if conf.Partitions == nil {
+		t.Fatal("Returned partitions was nil")
+	}
+	assert.Equal(t, 1, len(conf.Partitions), "Wrong partition count")
+
+	policyType := conf.Partitions[0].NodeSortPolicy.Type
+	weights := conf.Partitions[0].NodeSortPolicy.ResourceWeights
+	assert.Equal(t, 0, len(weights), "Expected empty weights")
+
+	policy, ok := NewNodeSortingPolicy(policyType, weights).(fairnessNodeSortingPolicy)
+	if !ok {
+		t.Fatal("Didn't get expected policy")
+	}
+
+	assert.Equal(t, 2, len(policy.resourceWeights), "Wrong size of resourceWeights")
+	assert.Equal(t, policy.resourceWeights["vcore"], 1.0, "Wrong weight for vcore")
+	assert.Equal(t, policy.resourceWeights["memory"], 1.0, "Wrong weight for memory")
+}
+
+func TestSpecifiedResourceWeightsFromConfig(t *testing.T) {
+	emptyConf := `
+partitions:
+  - name: default
+    nodesortpolicy:
+      type: fair
+      resourceweights:
+        vcore: 2.0
+        memory: 0.5
+        gpu: 5.0
+    queues:
+      - name: root
+        submitacl: '*'
+`
+	conf, err := configs.LoadSchedulerConfigFromByteArray([]byte(emptyConf))
+	assert.NilError(t, err, "No error is expected")
+	if conf == nil {
+		t.Fatal("Returned conf was nil")
+	}
+	if conf.Partitions == nil {
+		t.Fatal("Returned partitions was nil")
+	}
+	assert.Equal(t, 1, len(conf.Partitions), "Wrong partition count")
+
+	policyType := conf.Partitions[0].NodeSortPolicy.Type
+	weights := conf.Partitions[0].NodeSortPolicy.ResourceWeights
+	assert.Equal(t, 3, len(weights), "Expected populated weights")
+
+	policy, ok := NewNodeSortingPolicy(policyType, weights).(fairnessNodeSortingPolicy)
+	if !ok {
+		t.Fatal("Didn't get expected policy")
+	}
+
+	assert.Equal(t, 3, len(policy.resourceWeights), "Wrong size of resourceWeights")
+	assert.Equal(t, policy.resourceWeights["vcore"], 2.0, "Wrong weight for vcore")
+	assert.Equal(t, policy.resourceWeights["memory"], 0.5, "Wrong weight for memory")
+	assert.Equal(t, policy.resourceWeights["gpu"], 5.0, "Wrong weight for gpu")
+}
+
+func TestSortPolicyWeighting(t *testing.T) {
+	nc := NewNodeCollection("test")
+	weights := map[string]float64{
+		"vcore":  4.0,
+		"memory": 1.0,
+	}
+	fair, ok := NewNodeSortingPolicy("fair", weights).(fairnessNodeSortingPolicy)
+	if !ok {
+		t.Fatal("Didn't get fair policy")
+	}
+	bin, ok := NewNodeSortingPolicy("binpacking", weights).(binPackingNodeSortingPolicy)
+	if !ok {
+		t.Fatal("Didn't get binpacking policy")
+	}
+
+	nc.SetNodeSortingPolicy(fair)
+	totalRes := resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 2000, "memory": 16000})
+
+	proto1 := newProto("test1", totalRes, nil, map[string]string{})
+	node1 := NewNode(proto1)
+	if err := nc.AddNode(node1); err != nil {
+		t.Fatal("Failed to add node1")
+	}
+
+	proto2 := newProto("test2", totalRes, nil, map[string]string{})
+	node2 := NewNode(proto2)
+	if err := nc.AddNode(node2); err != nil {
+		t.Fatal("Failed to add node2")
+	}
+
+	// add allocations
+	res1 := resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 500, "memory": 12000})
+	alloc1 := newAllocation("test-app-1", uuid.NewString(), "test1", "root.default", res1)
+	node1.AddAllocation(alloc1)
+
+	res2 := resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 1500, "memory": 4000})
+	alloc2 := newAllocation("test-app-1", uuid.NewString(), "test2", "root.default", res2)
+	node2.AddAllocation(alloc2)
+
+	// node1 w/ fair: 25% vcore, 75% memory => ((.25 * 4) + (.75 * 1)) / 5 = 0.35
+	assert.Equal(t, 0.35, fair.ScoreNode(node1), "Wrong fair score for node1")
+
+	// node1 w/ binpacking: same but 1 - fair => 0.65
+	assert.Equal(t, 0.65, bin.ScoreNode(node1), "Wrong binpacking score for node1")
+
+	// node2 w/ fair: 75% vcore, 25% memory => ((.75 * 4) + (.25 * 1)) / 5 = 0.65
+	assert.Equal(t, 0.65, fair.ScoreNode(node2), "Wrong fair score for node2")
+
+	// node2 w/ binpacking: same but 1 - fair = 0.35
+	assert.Equal(t, 0.35, bin.ScoreNode(node2), "Wrong binpacking score for node2")
+
+	// node1 should be first as it is the least-loaded
+	nodes := make([]*Node, 0)
+	for it := nc.GetNodeIterator(); it.HasNext(); {
+		nodes = append(nodes, it.Next())
+	}
+
+	assert.Equal(t, 2, len(nodes), "node length != 2")
+	assert.Equal(t, node1.NodeID, nodes[0].NodeID, "wrong initial node (fair)")
+	assert.Equal(t, node2.NodeID, nodes[1].NodeID, "wrong second node (fair)")
+
+	// switch to binpacking
+	nc.SetNodeSortingPolicy(bin)
+
+	// node2 should now be first as it is most-loaded
+	nodes = make([]*Node, 0)
+	for it := nc.GetNodeIterator(); it.HasNext(); {
+		nodes = append(nodes, it.Next())
+	}
+
+	assert.Equal(t, 2, len(nodes), "node length != 2")
+	assert.Equal(t, node2.NodeID, nodes[0].NodeID, "wrong initial node (binpacking)")
+	assert.Equal(t, node1.NodeID, nodes[1].NodeID, "wrong second node (binpacking)")
+}
+
+func TestSortPolicy(t *testing.T) {
+	nc := NewNodeCollection("test")
+	bp := NewNodeSortingPolicy("binpacking", nil)
+	fair := NewNodeSortingPolicy("fair", nil)
+	nc.SetNodeSortingPolicy(bp)
+	totalRes := resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 2000, "memory": 4000})
+
+	proto1 := newProto("test1", totalRes, nil, map[string]string{})
+	node1 := NewNode(proto1)
+	if err := nc.AddNode(node1); err != nil {
+		t.Fatal("Failed to add node1")
+	}
+
+	proto2 := newProto("test2", totalRes, nil, map[string]string{})
+	node2 := NewNode(proto2)
+	if err := nc.AddNode(node2); err != nil {
+		t.Fatal("Failed to add node2")
+	}
+
+	// nodes should be in ascending order before any allocations
+	nodes := make([]*Node, 0)
+	for it := nc.GetNodeIterator(); it.HasNext(); {
+		nodes = append(nodes, it.Next())
+	}
+	assert.Equal(t, 2, len(nodes), "node length != 2")
+	assert.Equal(t, node1.NodeID, nodes[0].NodeID, "wrong initial node (binpacking, empty allocation)")
+	assert.Equal(t, node2.NodeID, nodes[1].NodeID, "wrong second node (binpacking, empty allocation)")
+
+	// change policy to fair, and we should see the same order
+	nc.SetNodeSortingPolicy(fair)
+
+	nodes = make([]*Node, 0)
+	for it := nc.GetNodeIterator(); it.HasNext(); {
+		nodes = append(nodes, it.Next())
+	}
+	assert.Equal(t, 2, len(nodes), "node length != 2")
+	assert.Equal(t, node1.NodeID, nodes[0].NodeID, "wrong initial node (fair, empty allocation)")
+	assert.Equal(t, node2.NodeID, nodes[1].NodeID, "wrong second node (fair, empty allocation)")
+
+	// reset back to binpacking
+	nc.SetNodeSortingPolicy(bp)
+
+	// add allocation to second node
+	half := resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 1000, "memory": 2000})
+	alloc := newAllocation("test-app-1", uuid.NewString(), "test2", "root.default", half)
+	node2.AddAllocation(alloc)
+
+	// node2 should now be first as it is the highest-loaded
+	nodes = make([]*Node, 0)
+	for it := nc.GetNodeIterator(); it.HasNext(); {
+		nodes = append(nodes, it.Next())
+	}
+
+	assert.Equal(t, 2, len(nodes), "node length != 2")
+	assert.Equal(t, node2.NodeID, nodes[0].NodeID, "wrong initial node (binpacking, node2 half-filled)")
+	assert.Equal(t, node1.NodeID, nodes[1].NodeID, "wrong second node (binpacking, node2 half-filled")
+
+	// change policy to fair and try again
+	nc.SetNodeSortingPolicy(fair)
+
+	// node1 should again be first, as it is least-loaded
+	nodes = make([]*Node, 0)
+	for it := nc.GetNodeIterator(); it.HasNext(); {
+		nodes = append(nodes, it.Next())
+	}
+	assert.Equal(t, 2, len(nodes), "node length != 2")
+	assert.Equal(t, node1.NodeID, nodes[0].NodeID, "wrong initial node (fair, node2 half-filled)")
+	assert.Equal(t, node2.NodeID, nodes[1].NodeID, "wrong second node (binpacking, node2 half-filled")
 }

--- a/pkg/scheduler/objects/sorters_test.go
+++ b/pkg/scheduler/objects/sorters_test.go
@@ -19,7 +19,6 @@
 package objects
 
 import (
-	"sort"
 	"strconv"
 	"testing"
 	"time"
@@ -102,97 +101,10 @@ func TestNoQueueLimits(t *testing.T) {
 	assertQueueList(t, queues, []int{1, 2, 0}, "fair no limit second")
 }
 
-func TestSortNodesBin(t *testing.T) {
-	policy := NewNodeSortingPolicy(policies.BinPackingPolicy.String())
-
-	// nil or empty list cannot panic
-	sortNodes(nil, policy)
-	list := make([]*Node, 0)
-	sortNodes(list, policy)
-	list = append(list, newNode("node-nil", nil))
-	sortNodes(list, policy)
-
-	// stable sort is used so equal resources stay where they were
-	res := resources.NewResourceFromMap(map[string]resources.Quantity{
-		"first": resources.Quantity(100)})
-
-	// setup to sort ascending
-	list = make([]*Node, 3)
-	for i := 0; i < 3; i++ {
-		num := strconv.Itoa(i)
-		node := newNodeRes("node-"+num, resources.Multiply(res, int64(3-i)))
-		list[i] = node
-	}
-	// nodes should come back in order 2 (100), 1 (200), 0 (300)
-	sortNodes(list, policy)
-	assertNodeList(t, list, []int{2, 1, 0}, "bin base order")
-
-	// change node-1 on place 1 in the slice to have no res
-	list[1] = newNodeRes("node-1", resources.Multiply(res, 0))
-	// nodes should come back in order 1 (0), 2 (100), 0 (300)
-	sortNodes(list, policy)
-	assertNodeList(t, list, []int{2, 0, 1}, "bin no res node-1")
-
-	// change node-1 on place 0 in the slice to have 300 res
-	list[0] = newNodeRes("node-1", resources.Multiply(res, 3))
-	// nodes should come back in order 2 (100), 1 (300), 0 (300)
-	sortNodes(list, policy)
-	assertNodeList(t, list, []int{2, 1, 0}, "bin node-1 same as node-0")
-
-	// change node-0 on place 2 in the slice to have -300 res
-	list[2] = newNodeRes("node-0", resources.Multiply(res, -3))
-	// nodes should come back in order 0 (-300), 2 (100), 1 (300)
-	sortNodes(list, policy)
-	assertNodeList(t, list, []int{0, 2, 1}, "bin node-0 negative")
-}
-
-func TestSortNodesFair(t *testing.T) {
-	policy := NewNodeSortingPolicy(policies.FairnessPolicy.String())
-
-	// nil or empty list cannot panic
-	sortNodes(nil, policy)
-	list := make([]*Node, 0)
-	sortNodes(list, policy)
-	list = append(list, newNode("node-nil", nil))
-	sortNodes(list, policy)
-
-	// stable sort is used so equal resources stay where they were
-	res := resources.NewResourceFromMap(map[string]resources.Quantity{
-		"first": resources.Quantity(100)})
-	// setup to sort descending
-	list = make([]*Node, 3)
-	for i := 0; i < 3; i++ {
-		num := strconv.Itoa(i)
-		node := newNodeRes("node-"+num, resources.Multiply(res, int64(1+i)))
-		list[i] = node
-	}
-	// nodes should come back in order 2 (300), 1 (200), 0 (100)
-	sortNodes(list, policy)
-	assertNodeList(t, list, []int{2, 1, 0}, "fair base order")
-
-	// change node-1 on place 1 in the slice to have no res
-	list[1] = newNodeRes("node-1", resources.Multiply(res, 0))
-	// nodes should come back in order 2 (300), 0 (100), 1 (0)
-	sortNodes(list, policy)
-	assertNodeList(t, list, []int{1, 2, 0}, "fair no res node-1")
-
-	// change node-1 on place 2 in the slice to have 300 res
-	list[2] = newNodeRes("node-1", resources.Multiply(res, 3))
-	// nodes should come back in order 2 (300), 1 (300), 0 (100)
-	sortNodes(list, policy)
-	assertNodeList(t, list, []int{2, 1, 0}, "fair node-1 same as node-2")
-
-	// change node-2 on place 0 in the slice to have -300 res
-	list[0] = newNodeRes("node-2", resources.Multiply(res, -3))
-	// nodes should come back in order 1 (300), 0 (100), 2 (-300)
-	sortNodes(list, policy)
-	assertNodeList(t, list, []int{1, 0, 2}, "fair node-2 negative")
-}
-
 func TestSortAppsNoPending(t *testing.T) {
 	// stable sort is used so equal values stay where they were
 	res := resources.NewResourceFromMap(map[string]resources.Quantity{
-		"first": resources.Quantity(100)})
+		"vcore": resources.Quantity(100)})
 	input := make(map[string]*Application, 4)
 	for i := 0; i < 2; i++ {
 		num := strconv.Itoa(i)
@@ -223,7 +135,7 @@ func TestSortAppsNoPending(t *testing.T) {
 func TestSortAppsFifo(t *testing.T) {
 	// stable sort is used so equal values stay where they were
 	res := resources.NewResourceFromMap(map[string]resources.Quantity{
-		"first": resources.Quantity(100)})
+		"vcore": resources.Quantity(100)})
 	// setup to sort descending: all apps have pending resources
 	input := make(map[string]*Application, 4)
 	for i := 0; i < 4; i++ {
@@ -244,7 +156,7 @@ func TestSortAppsFifo(t *testing.T) {
 func TestSortAppsFair(t *testing.T) {
 	// stable sort is used so equal values stay where they were
 	res := resources.NewResourceFromMap(map[string]resources.Quantity{
-		"first": resources.Quantity(100)})
+		"vcore": resources.Quantity(100)})
 	// setup to sort descending: all apps have pending resources
 	input := make(map[string]*Application, 4)
 	for i := 0; i < 4; i++ {
@@ -284,7 +196,7 @@ func TestSortAppsFair(t *testing.T) {
 func TestSortAppsStateAware(t *testing.T) {
 	// stable sort is used so equal values stay where they were
 	res := resources.NewResourceFromMap(map[string]resources.Quantity{
-		"first": resources.Quantity(100)})
+		"vcore": resources.Quantity(100)})
 	// setup all apps with pending resources, all accepted state
 	input := make(map[string]*Application, 4)
 	for i := 0; i < 4; i++ {
@@ -339,7 +251,7 @@ func TestSortAppsStateAware(t *testing.T) {
 func TestSortAsks(t *testing.T) {
 	// stable sort is used so equal values stay where they were
 	res := resources.NewResourceFromMap(map[string]resources.Quantity{
-		"first": resources.Quantity(1)})
+		"vcore": resources.Quantity(1)})
 	list := make([]*AllocationAsk, 4)
 	for i := 0; i < 4; i++ {
 		num := strconv.Itoa(i)
@@ -412,12 +324,4 @@ func assertAppListLength(t *testing.T, list []*Application, apps []string, name 
 	for i, app := range list {
 		assert.Equal(t, apps[i], app.ApplicationID, "test name: %s", name)
 	}
-}
-
-func sortNodes(nodes []*Node, sortType NodeSortingPolicy) {
-	sort.SliceStable(nodes, func(i, j int) bool {
-		l := nodes[i]
-		r := nodes[j]
-		return sortType.ScoreNode(l) < sortType.ScoreNode(r)
-	})
 }

--- a/pkg/scheduler/partition.go
+++ b/pkg/scheduler/partition.go
@@ -149,7 +149,7 @@ func (pc *PartitionContext) updateNodeSortingPolicy(conf configs.PartitionConfig
 		log.Logger().Info("NodeSorting policy set from config",
 			zap.String("policyName", configuredPolicy.String()))
 	}
-	pc.nodes.SetNodeSortingPolicy(objects.NewNodeSortingPolicy(conf.NodeSortPolicy.Type))
+	pc.nodes.SetNodeSortingPolicy(objects.NewNodeSortingPolicy(conf.NodeSortPolicy.Type, conf.NodeSortPolicy.ResourceWeights))
 }
 
 func (pc *PartitionContext) updatePartitionDetails(conf configs.PartitionConfig) error {

--- a/pkg/scheduler/partition_test.go
+++ b/pkg/scheduler/partition_test.go
@@ -207,12 +207,12 @@ func TestAddNodeWithAllocations(t *testing.T) {
 
 	// add a new app
 	app := newApplication(appID1, "default", defQueue)
-	appRes := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 1})
+	appRes := resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 1})
 	err = partition.AddApplication(app)
 	assert.NilError(t, err, "add application to partition should not have failed")
 
 	// add a node with allocations
-	nodeRes := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 10})
+	nodeRes := resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 10})
 	node := newNodeMaxResource(nodeID1, nodeRes)
 
 	// fail with an unknown app
@@ -277,9 +277,9 @@ func TestRemoveNodeWithAllocations(t *testing.T) {
 	assert.NilError(t, err, "add application to partition should not have failed")
 
 	// add a node with allocations: must have the correct app added already
-	nodeRes := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 1000})
+	nodeRes := resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 1000})
 	node := newNodeMaxResource(nodeID1, nodeRes)
-	appRes := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 1})
+	appRes := resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 1})
 	ask := newAllocationAsk("alloc-1", appID1, appRes)
 	allocUUID := "alloc-1-uuid"
 	alloc := objects.NewAllocation(allocUUID, nodeID1, ask)
@@ -345,7 +345,7 @@ func TestAddAppTaskGroup(t *testing.T) {
 	assert.NilError(t, err, "partition create failed")
 
 	// add a new app: TG specified with resource no max set on the queue
-	task := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 10})
+	task := resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 10})
 	app := newApplicationTG(appID1, "default", defQueue, task)
 	assert.Assert(t, resources.Equals(app.GetPlaceholderAsk(), task), "placeholder ask not set as expected")
 	// queue sort policy is FIFO this should work
@@ -376,7 +376,7 @@ func TestAddAppTaskGroup(t *testing.T) {
 		Parent:     false,
 		Queues:     nil,
 		Properties: map[string]string{configs.ApplicationSortPolicy: "stateaware"},
-		Resources:  configs.Resources{Max: map[string]string{"first": "5"}},
+		Resources:  configs.Resources{Max: map[string]string{"vcore": "5"}},
 	})
 	assert.NilError(t, err, "updating queue should not have failed (stateaware & max)")
 	queue.UpdateSortType()
@@ -390,7 +390,7 @@ func TestAddAppTaskGroup(t *testing.T) {
 		Name:      "default",
 		Parent:    false,
 		Queues:    nil,
-		Resources: configs.Resources{Max: map[string]string{"first": "20"}},
+		Resources: configs.Resources{Max: map[string]string{"vcore": "20"}},
 	})
 	assert.NilError(t, err, "updating queue should not have failed (max resource)")
 	err = partition.AddApplication(app)
@@ -407,7 +407,7 @@ func TestRemoveApp(t *testing.T) {
 	err = partition.AddApplication(app)
 	assert.NilError(t, err, "add application to partition should not have failed")
 	// add a node to allow adding an allocation
-	node1 := newNodeMaxResource(nodeID1, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 1000}))
+	node1 := newNodeMaxResource(nodeID1, resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 1000}))
 	// add a node this must work
 	err = partition.AddNode(node1, nil)
 	assert.NilError(t, err, "add node to partition should not have failed")
@@ -415,7 +415,7 @@ func TestRemoveApp(t *testing.T) {
 		t.Fatalf("node not added to partition as expected (node nil)")
 	}
 
-	appRes := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 1})
+	appRes := resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 1})
 	ask := newAllocationAsk("alloc-nr", appNotRemoved, appRes)
 	uuid := "alloc-nr-uuid"
 	alloc := objects.NewAllocation(uuid, nodeID1, ask)
@@ -465,14 +465,14 @@ func TestRemoveAppAllocs(t *testing.T) {
 	err = partition.AddApplication(app)
 	assert.NilError(t, err, "add application to partition should not have failed")
 	// add a node to allow adding an allocation
-	node1 := newNodeMaxResource(nodeID1, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 1000}))
+	node1 := newNodeMaxResource(nodeID1, resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 1000}))
 	// add a node this must work
 	err = partition.AddNode(node1, nil)
 	assert.NilError(t, err, "add node to partition should not have failed")
 	if partition.GetNode(nodeID1) == nil {
 		t.Fatalf("node not added to partition as expected (node nil)")
 	}
-	appRes := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 1})
+	appRes := resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 1})
 	ask := newAllocationAsk("alloc-nr", appNotRemoved, appRes)
 	alloc := objects.NewAllocation("alloc-nr-uuid", nodeID1, ask)
 	err = partition.addAllocation(alloc)
@@ -643,7 +643,7 @@ func TestUpdateQueues(t *testing.T) {
 	assert.Assert(t, def.IsDraining(), "'root.default' queue should have been marked for removal")
 
 	var resExpect *resources.Resource
-	resMap := map[string]string{"first": "1"}
+	resMap := map[string]string{"vcore": "1"}
 	resExpect, err = resources.NewResourceFromConf(resMap)
 	assert.NilError(t, err, "resource from conf failed")
 
@@ -717,7 +717,7 @@ func TestTryAllocate(t *testing.T) {
 	// the ask with the higher priority is the second one added alloc-2 for app-1
 	app := newApplication(appID1, "default", "root.parent.sub-leaf")
 
-	res, err := resources.NewResourceFromConf(map[string]string{"first": "1"})
+	res, err := resources.NewResourceFromConf(map[string]string{"vcore": "1"})
 	assert.NilError(t, err, "failed to create resource")
 
 	// add to the partition
@@ -780,7 +780,7 @@ func TestTryAllocateLarge(t *testing.T) {
 	objects.SetReservationDelay(10 * time.Nanosecond)
 	defer objects.SetReservationDelay(2 * time.Second)
 
-	res, err := resources.NewResourceFromConf(map[string]string{"first": "100"})
+	res, err := resources.NewResourceFromConf(map[string]string{"vcore": "100"})
 	assert.NilError(t, err, "failed to create resource")
 
 	app := newApplication(appID1, "default", "root.parent.sub-leaf")
@@ -815,7 +815,7 @@ func TestAllocReserveNewNode(t *testing.T) {
 	node2 := partition.GetNode(nodeID2)
 	node2.SetSchedulable(false)
 
-	res, err := resources.NewResourceFromConf(map[string]string{"first": "8"})
+	res, err := resources.NewResourceFromConf(map[string]string{"vcore": "8"})
 	assert.NilError(t, err, "failed to create resource")
 
 	// only one resource for alloc fits on a node
@@ -870,7 +870,7 @@ func TestTryAllocateReserve(t *testing.T) {
 	// sub-leaf will have an app with 2 requests and thus more unconfirmed resources compared to leaf2
 	// this should filter up in the parent and the 1st allocate should show an app-1 allocation
 	// the ask with the higher priority is the second one added alloc-2 for app-1
-	res, err := resources.NewResourceFromConf(map[string]string{"first": "1"})
+	res, err := resources.NewResourceFromConf(map[string]string{"vcore": "1"})
 	assert.NilError(t, err, "failed to create resource")
 
 	app := newApplication(appID1, "default", "root.parent.sub-leaf")
@@ -935,7 +935,7 @@ func TestTryAllocateWithReserved(t *testing.T) {
 		t.Fatalf("empty cluster reserved allocate returned allocation: %v", alloc)
 	}
 
-	res, err := resources.NewResourceFromConf(map[string]string{"first": "5"})
+	res, err := resources.NewResourceFromConf(map[string]string{"vcore": "5"})
 	assert.NilError(t, err, "failed to create resource")
 
 	app := newApplication(appID1, "default", "root.parent.sub-leaf")
@@ -988,7 +988,7 @@ func TestScheduleRemoveReservedAsk(t *testing.T) {
 	objects.SetReservationDelay(10 * time.Nanosecond)
 	defer objects.SetReservationDelay(2 * time.Second)
 
-	res, err := resources.NewResourceFromConf(map[string]string{"first": "4"})
+	res, err := resources.NewResourceFromConf(map[string]string{"vcore": "4"})
 	assert.NilError(t, err, "resource creation failed")
 	app := newApplication(appID1, "default", "root.parent.sub-leaf")
 	err = partition.AddApplication(app)
@@ -1065,7 +1065,7 @@ func TestUpdateRootQueue(t *testing.T) {
 	if partition == nil {
 		t.Fatal("partition create failed")
 	}
-	res, err := resources.NewResourceFromConf(map[string]string{"first": "20"})
+	res, err := resources.NewResourceFromConf(map[string]string{"vcore": "20"})
 	assert.NilError(t, err, "resource creation failed")
 	assert.Assert(t, resources.Equals(res, partition.totalPartitionResource), "partition resource not set as expected")
 	assert.Assert(t, resources.Equals(res, partition.root.GetMaxResource()), "root max resource not set as expected")
@@ -1192,12 +1192,12 @@ func TestUpdateNode(t *testing.T) {
 }
 
 func TestAddTGApplication(t *testing.T) {
-	limit := map[string]string{"first": "1"}
+	limit := map[string]string{"vcore": "1"}
 	partition, err := newLimitedPartition(limit)
 	assert.NilError(t, err, "partition create failed")
 	// add a app with TG that does not fit in the queue
 	var tgRes *resources.Resource
-	tgRes, err = resources.NewResourceFromConf(map[string]string{"first": "10"})
+	tgRes, err = resources.NewResourceFromConf(map[string]string{"vcore": "10"})
 	assert.NilError(t, err, "failed to create resource")
 	app := newApplicationTG(appID1, "default", "root.limited", tgRes)
 	err = partition.AddApplication(app)
@@ -1206,7 +1206,7 @@ func TestAddTGApplication(t *testing.T) {
 	}
 
 	// add a app with TG that does fit in the queue
-	limit = map[string]string{"first": "100"}
+	limit = map[string]string{"vcore": "100"}
 	partition, err = newLimitedPartition(limit)
 	assert.NilError(t, err, "partition create failed")
 	err = partition.AddApplication(app)
@@ -1227,7 +1227,7 @@ func TestAddTGAppDynamic(t *testing.T) {
 	assert.NilError(t, err, "partition create failed")
 	// add a app with TG that does fit in the dynamic queue (no limit)
 	var tgRes *resources.Resource
-	tgRes, err = resources.NewResourceFromConf(map[string]string{"first": "10"})
+	tgRes, err = resources.NewResourceFromConf(map[string]string{"vcore": "10"})
 	assert.NilError(t, err, "failed to create resource")
 	tags := map[string]string{"taskqueue": "unlimited"}
 	app := newApplicationTGTags(appID1, "default", "unknown", tgRes, tags)
@@ -1235,7 +1235,7 @@ func TestAddTGAppDynamic(t *testing.T) {
 	assert.NilError(t, err, "app-1 should have been added to the partition")
 	assert.Equal(t, app.GetQueuePath(), "root.unlimited", "app-1 not placed in expected queue")
 
-	jsonRes := "{\"resources\":{\"first\":{\"value\":10}}}"
+	jsonRes := "{\"resources\":{\"vcore\":{\"value\":10}}}"
 	tags = map[string]string{"taskqueue": "same", objects.AppTagNamespaceResourceQuota: jsonRes}
 	app = newApplicationTGTags(appID2, "default", "unknown", tgRes, tags)
 	err = partition.AddApplication(app)
@@ -1243,7 +1243,7 @@ func TestAddTGAppDynamic(t *testing.T) {
 	assert.Equal(t, partition.getApplication(appID2), app, "partition failed to add app incorrect app returned")
 	assert.Equal(t, app.GetQueuePath(), "root.same", "app-2 not placed in expected queue")
 
-	jsonRes = "{\"resources\":{\"first\":{\"value\":1}}}"
+	jsonRes = "{\"resources\":{\"vcore\":{\"value\":1}}}"
 	tags = map[string]string{"taskqueue": "smaller", objects.AppTagNamespaceResourceQuota: jsonRes}
 	app = newApplicationTGTags(appID3, "default", "unknown", tgRes, tags)
 	err = partition.AddApplication(app)
@@ -1272,11 +1272,11 @@ func TestPlaceholderAndRealAllocationResMismatch(t *testing.T) {
 
 	var tgRes, res *resources.Resource
 	var res1 *resources.Resource
-	tgRes, err = resources.NewResourceFromConf(map[string]string{"first": "10"})
+	tgRes, err = resources.NewResourceFromConf(map[string]string{"vcore": "10"})
 	assert.NilError(t, err, "failed to create resource")
-	res, err = resources.NewResourceFromConf(map[string]string{"first": "1"})
+	res, err = resources.NewResourceFromConf(map[string]string{"vcore": "1"})
 	assert.NilError(t, err, "failed to create resource")
-	res1, err = resources.NewResourceFromConf(map[string]string{"first": "2"})
+	res1, err = resources.NewResourceFromConf(map[string]string{"vcore": "2"})
 	assert.NilError(t, err, "failed to create resource")
 
 	// add node to allow allocation
@@ -1331,7 +1331,7 @@ func TestPlaceholderAndRealAllocationResMismatch(t *testing.T) {
 	assert.Equal(t, record.Type, si.EventRecord_REQUEST)
 	assert.Equal(t, record.ObjectID, "real-2")
 	assert.Equal(t, record.GroupID, "app-1")
-	assert.Equal(t, record.Message, "Real Pod real-2 allocation [first:2] is not matching with placeholder ph-1 allocation [first:1] in application app-1")
+	assert.Equal(t, record.Message, "Real Pod real-2 allocation [vcore:2] is not matching with placeholder ph-1 allocation [vcore:1] in application app-1")
 	assert.Equal(t, record.Reason, "Resource Allocation Mismatch between real and placeholder")
 }
 
@@ -1344,9 +1344,9 @@ func TestTryPlaceholderAllocate(t *testing.T) {
 	}
 
 	var tgRes, res *resources.Resource
-	tgRes, err = resources.NewResourceFromConf(map[string]string{"first": "10"})
+	tgRes, err = resources.NewResourceFromConf(map[string]string{"vcore": "10"})
 	assert.NilError(t, err, "failed to create resource")
-	res, err = resources.NewResourceFromConf(map[string]string{"first": "1"})
+	res, err = resources.NewResourceFromConf(map[string]string{"vcore": "1"})
 	assert.NilError(t, err, "failed to create resource")
 
 	// add node to allow allocation
@@ -1463,9 +1463,9 @@ func TestFailReplacePlaceholder(t *testing.T) {
 	plugin := newFakePredicatePlugin(false, map[string]int{nodeID1: -1})
 	plugins.RegisterSchedulerPlugin(plugin)
 	var tgRes, res *resources.Resource
-	tgRes, err = resources.NewResourceFromConf(map[string]string{"first": "10"})
+	tgRes, err = resources.NewResourceFromConf(map[string]string{"vcore": "10"})
 	assert.NilError(t, err, "failed to create resource")
-	res, err = resources.NewResourceFromConf(map[string]string{"first": "1"})
+	res, err = resources.NewResourceFromConf(map[string]string{"vcore": "1"})
 	assert.NilError(t, err, "failed to create resource")
 
 	// add node to allow allocation
@@ -1572,7 +1572,7 @@ func TestAddAllocationAsk(t *testing.T) {
 	assert.NilError(t, err, "app-1 should have been added to the partition")
 	// a simple ask (no repeat should fail)
 	var res *resources.Resource
-	res, err = resources.NewResourceFromConf(map[string]string{"first": "10"})
+	res, err = resources.NewResourceFromConf(map[string]string{"vcore": "10"})
 	assert.NilError(t, err, "failed to create resource")
 	askKey := "ask-key-1"
 	ask := si.AllocationAsk{
@@ -1603,7 +1603,7 @@ func TestRemoveAllocationAsk(t *testing.T) {
 	err = partition.AddApplication(app)
 	assert.NilError(t, err, "app-1 should have been added to the partition")
 	var res *resources.Resource
-	res, err = resources.NewResourceFromConf(map[string]string{"first": "10"})
+	res, err = resources.NewResourceFromConf(map[string]string{"vcore": "10"})
 	assert.NilError(t, err, "failed to create resource")
 	askKey := "ask-key-1"
 	ask := newAllocationAsk(askKey, appID1, res)

--- a/pkg/scheduler/utilities_test.go
+++ b/pkg/scheduler/utilities_test.go
@@ -258,7 +258,7 @@ func createQueuesNodes(t *testing.T) *PartitionContext {
 	partition, err := newConfiguredPartition()
 	assert.NilError(t, err, "test partition create failed with error")
 	var res *resources.Resource
-	res, err = resources.NewResourceFromConf(map[string]string{"first": "10"})
+	res, err = resources.NewResourceFromConf(map[string]string{"vcore": "10"})
 	assert.NilError(t, err, "failed to create basic resource")
 	err = partition.AddNode(newNodeMaxResource("node-1", res), nil)
 	assert.NilError(t, err, "test node1 add failed unexpected")


### PR DESCRIPTION
### What is this PR for?
Updates node sorting algorithms to take into account resource weights when calculating scores. Scores are now based on percentage of a node utilized rather than absolute values. This prevents priority inversion when we have resources with large absolute values. By default, vcores and memory are given equal weight.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-847

### How should this be tested?
Unit tests were performed as well as manual testing of various workloads on a test cluster.

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [x] - It needs documentation.
