### PR TITLE
[YUNIKORN-854] node removal with inflight placeholder replacements

### DIFF
--- a/pkg/scheduler/context.go
+++ b/pkg/scheduler/context.go
@@ -577,11 +577,14 @@ func (cc *ClusterContext) updateNodes(request *si.UpdateRequest) {
 		case si.UpdateNodeInfo_DECOMISSION:
 			// set the state to not schedulable then tell the partition to clean up
 			node.SetSchedulable(false)
-			released := partition.removeNode(node.NodeID)
+			released, confirmed := partition.removeNode(node.NodeID)
 			// notify the shim allocations have been released from node
 			if len(released) != 0 {
 				cc.notifyRMAllocationReleased(partition.RmID, released, si.TerminationType_STOPPED_BY_RM,
 					fmt.Sprintf("Node %s Removed", node.NodeID))
+			}
+			for _, confirm := range confirmed {
+				cc.notifyRMNewAllocation(partition.RmID, confirm)
 			}
 		}
 	}

--- a/pkg/scheduler/context_test.go
+++ b/pkg/scheduler/context_test.go
@@ -103,7 +103,7 @@ func TestAddUnlimitedNode(t *testing.T) {
 	assert.Assert(t, len(handler.rejectedNodes) == 0, "There should be no rejected nodes")
 	assert.Equal(t, handler.acceptedNodes[0].NodeID, unlimitedNode.NodeID, "The accepted node is not the unlimited one")
 
-	// 3. there is already an unlimited node registeredvar newNodes []*si.NewNodeInfo
+	// 3. there is already an unlimited node registered
 	unlimitedNode2 := &si.NewNodeInfo{
 		NodeID:     "unlimited2",
 		Attributes: map[string]string{"yunikorn.apache.org/nodeType": "unlimited", "si/node-partition": "default"},
@@ -128,7 +128,7 @@ func TestAddUnlimitedNode(t *testing.T) {
 	newNodes2 = append(newNodes2, unlimitedNode, regularNode)
 	request2.NewSchedulableNodes = newNodes2
 	handler.reset()
-	partition.removeNode(unlimitedNode.NodeID)
+	_, _ = partition.removeNode(unlimitedNode.NodeID)
 	context.addNodes(request2)
 	assert.Assert(t, handler.eventHandled, "Event should have been handled")
 	assert.Assert(t, len(handler.acceptedNodes) == 1, "There should be only one accepted node")

--- a/pkg/scheduler/objects/application.go
+++ b/pkg/scheduler/objects/application.go
@@ -549,7 +549,7 @@ func (sa *Application) RecoverAllocationAsk(ask *AllocationAsk) {
 	}
 }
 
-func (sa *Application) updateAskRepeat(allocKey string, delta int32) (*resources.Resource, error) {
+func (sa *Application) UpdateAskRepeat(allocKey string, delta int32) (*resources.Resource, error) {
 	sa.Lock()
 	defer sa.Unlock()
 	if ask := sa.requests[allocKey]; ask != nil {

--- a/pkg/scheduler/objects/application_test.go
+++ b/pkg/scheduler/objects/application_test.go
@@ -256,11 +256,12 @@ func TestUpdateRepeat(t *testing.T) {
 	app.queue = queue
 
 	// failure cases
-	delta, err := app.updateAskRepeat("", 0)
+	var delta *resources.Resource
+	delta, err = app.UpdateAskRepeat("", 0)
 	if err == nil || delta != nil {
 		t.Error("empty ask key should not have been found")
 	}
-	delta, err = app.updateAskRepeat("unknown", 0)
+	delta, err = app.UpdateAskRepeat("unknown", 0)
 	if err == nil || delta != nil {
 		t.Error("unknown ask key should not have been found")
 	}
@@ -270,22 +271,22 @@ func TestUpdateRepeat(t *testing.T) {
 	ask := newAllocationAskRepeat(aKey, appID1, res, 1)
 	err = app.AddAllocationAsk(ask)
 	assert.NilError(t, err, "ask should have been added to app")
-	delta, err = app.updateAskRepeat(aKey, 0)
+	delta, err = app.UpdateAskRepeat(aKey, 0)
 	if err != nil || !resources.IsZero(delta) {
 		t.Errorf("0 increase should return zero delta and did not: %v, err %v", delta, err)
 	}
-	delta, err = app.updateAskRepeat(aKey, 1)
+	delta, err = app.UpdateAskRepeat(aKey, 1)
 	if err != nil || !resources.Equals(res, delta) {
 		t.Errorf("increase did not return correct delta, err %v, expected %v got %v", err, res, delta)
 	}
 
 	// decrease to zero
-	delta, err = app.updateAskRepeat(aKey, -2)
+	delta, err = app.UpdateAskRepeat(aKey, -2)
 	if err != nil || !resources.Equals(resources.Multiply(res, -2), delta) {
 		t.Errorf("decrease did not return correct delta, err %v, expected %v got %v", err, resources.Multiply(res, -2), delta)
 	}
 	// decrease to below zero
-	delta, err = app.updateAskRepeat(aKey, -1)
+	delta, err = app.UpdateAskRepeat(aKey, -1)
 	if err == nil || delta != nil {
 		t.Errorf("decrease did not return correct delta, err %v, delta %v", err, delta)
 	}

--- a/pkg/scheduler/objects/queue_test.go
+++ b/pkg/scheduler/objects/queue_test.go
@@ -480,7 +480,7 @@ func TestSortApplications(t *testing.T) {
 		t.Errorf("sorted application is missing expected app: %v", sortedApp)
 	}
 	// set 0 repeat
-	_, err = app.updateAskRepeat("alloc-1", -1)
+	_, err = app.UpdateAskRepeat("alloc-1", -1)
 	if err != nil || len(leaf.sortApplications(true)) != 0 {
 		t.Errorf("app with ask but 0 pending resources should not be in sorted apps: %v (err = %v)", app, err)
 	}

--- a/pkg/scheduler/partition_manager.go
+++ b/pkg/scheduler/partition_manager.go
@@ -138,7 +138,7 @@ func (manager partitionManager) remove() {
 		zap.Int("numOfNodes", len(nodes)),
 		zap.String("partitionName", manager.pc.Name))
 	for i := range nodes {
-		_ = manager.pc.removeNode(nodes[i].NodeID)
+		_, _ = manager.pc.removeNode(nodes[i].NodeID)
 	}
 	log.Logger().Info("removing partition",
 		zap.String("partitionName", manager.pc.Name))

--- a/pkg/scheduler/utilities_test.go
+++ b/pkg/scheduler/utilities_test.go
@@ -19,7 +19,6 @@
 package scheduler
 
 import (
-	"strconv"
 	"testing"
 
 	"gotest.tools/assert"
@@ -41,6 +40,7 @@ const (
 	rmID      = "testRM"
 	taskGroup = "tg-1"
 	phID      = "ph-1"
+	allocID   = "alloc-1"
 )
 
 func newBasePartition() (*PartitionContext, error) {
@@ -227,27 +227,6 @@ func newNodeWithResources(nodeID string, max, occupied *resources.Resource) *obj
 
 func newNodeMaxResource(nodeID string, max *resources.Resource) *objects.Node {
 	return newNodeWithResources(nodeID, max, nil)
-}
-
-// Simple node with just an ID in the node.
-// That is all we need for iteration
-func newNode(nodeID string) *objects.Node {
-	proto := &si.NewNodeInfo{
-		NodeID:     nodeID,
-		Attributes: nil,
-	}
-	return objects.NewNode(proto)
-}
-
-// A list of nodes that can be iterated over.
-func newSchedNodeList(number int) []*objects.Node {
-	list := make([]*objects.Node, number)
-	for i := 0; i < number; i++ {
-		num := strconv.Itoa(i)
-		node := newNode("node-" + num)
-		list[i] = node
-	}
-	return list
 }
 
 // partition with an expected basic queue hierarchy


### PR DESCRIPTION
### What is this PR for?
If a node has a placeholder while the node is removed the cleanup leaves
inflight replacements untouched. This can lead to unlinked allocations
on a secondary node or asks that never get allocated.
Handling three cases for node removal linked to placeholders:
* the removed node contains both the placeholder and real allocations,
  the real allocation is retried (without placeholder)
* the removed node contains only the real allocation,
  placeholder is unlinked and will be removed after confirmation by shim
  the real allocation is retried (without placeholder)
* the removed node contains only the placeholder,
  the real allocation is confirmed on the 2nd node

### What type of PR is it?
* [X] - Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-854

### How should this be tested?
Unit tests are added as part of the change
