### PR TITLE
[YUNIKORN-859] Add "resource weighting" to /ws/v1/partitions

### DIFF
--- a/pkg/scheduler/objects/nodesorting.go
+++ b/pkg/scheduler/objects/nodesorting.go
@@ -30,6 +30,7 @@ import (
 type NodeSortingPolicy interface {
 	PolicyType() policies.SortingPolicy
 	ScoreNode(node *Node) float64
+	ResourceWeights() map[string]float64
 }
 
 type binPackingNodeSortingPolicy struct {
@@ -83,6 +84,22 @@ func (p binPackingNodeSortingPolicy) ScoreNode(node *Node) float64 {
 func (p fairnessNodeSortingPolicy) ScoreNode(node *Node) float64 {
 	// choose least loaded node first (score == percentage used)
 	return absResourceUsage(node, &p.resourceWeights)
+}
+
+func (p binPackingNodeSortingPolicy) ResourceWeights() map[string]float64 {
+	weights := make(map[string]float64, len(p.resourceWeights))
+	for k, v := range p.resourceWeights {
+		weights[k] = v
+	}
+	return weights
+}
+
+func (p fairnessNodeSortingPolicy) ResourceWeights() map[string]float64 {
+	weights := make(map[string]float64, len(p.resourceWeights))
+	for k, v := range p.resourceWeights {
+		weights[k] = v
+	}
+	return weights
 }
 
 // Return a default set of resource weights if not otherwise specified.

--- a/pkg/scheduler/objects/nodesorting.go
+++ b/pkg/scheduler/objects/nodesorting.go
@@ -86,20 +86,20 @@ func (p fairnessNodeSortingPolicy) ScoreNode(node *Node) float64 {
 	return absResourceUsage(node, &p.resourceWeights)
 }
 
-func (p binPackingNodeSortingPolicy) ResourceWeights() map[string]float64 {
-	weights := make(map[string]float64, len(p.resourceWeights))
-	for k, v := range p.resourceWeights {
+func cloneWeights(source map[string]float64) map[string]float64 {
+	weights := make(map[string]float64, len(source))
+	for k, v := range source {
 		weights[k] = v
 	}
 	return weights
 }
 
+func (p binPackingNodeSortingPolicy) ResourceWeights() map[string]float64 {
+	return cloneWeights(p.resourceWeights)
+}
+
 func (p fairnessNodeSortingPolicy) ResourceWeights() map[string]float64 {
-	weights := make(map[string]float64, len(p.resourceWeights))
-	for k, v := range p.resourceWeights {
-		weights[k] = v
-	}
-	return weights
+	return cloneWeights(p.resourceWeights)
 }
 
 // Return a default set of resource weights if not otherwise specified.

--- a/pkg/scheduler/partition.go
+++ b/pkg/scheduler/partition.go
@@ -1331,7 +1331,7 @@ func (pc *PartitionContext) GetStateTime() time.Time {
 	return pc.stateTime
 }
 
-func (pc *PartitionContext) GetNodeSortingPolicy() policies.SortingPolicy {
+func (pc *PartitionContext) GetNodeSortingPolicyType() policies.SortingPolicy {
 	pc.RLock()
 	defer pc.RUnlock()
 	policy := pc.nodes.GetNodeSortingPolicy()
@@ -1339,6 +1339,16 @@ func (pc *PartitionContext) GetNodeSortingPolicy() policies.SortingPolicy {
 		return policies.FairnessPolicy
 	}
 	return policy.PolicyType()
+}
+
+func (pc *PartitionContext) GetNodeSortingResourceWeights() map[string]float64 {
+	pc.RLock()
+	defer pc.RUnlock()
+	policy := pc.nodes.GetNodeSortingPolicy()
+	if policy == nil {
+		return make(map[string]float64)
+	}
+	return policy.ResourceWeights()
 }
 
 func (pc *PartitionContext) moveTerminatedApp(appID string) {

--- a/pkg/webservice/dao/partition_info.go
+++ b/pkg/webservice/dao/partition_info.go
@@ -28,7 +28,7 @@ type PartitionInfo struct {
 	ClusterID               string            `json:"clusterId"`
 	Name                    string            `json:"name"`
 	Capacity                PartitionCapacity `json:"capacity"`
-	NodeSortingPolicy       string            `json:"nodeSortingPolicy"`
+	NodeSortingPolicy       NodeSortingPolicy `json:"nodeSortingPolicy"`
 	Applications            map[string]int    `json:"applications"`
 	State                   string            `json:"state"`
 	LastStateTransitionTime string            `json:"lastStateTransitionTime"`
@@ -42,4 +42,9 @@ type PartitionCapacity struct {
 type NodeInfo struct {
 	NodeID     string `json:"nodeId"`
 	Capability string `json:"capability"`
+}
+
+type NodeSortingPolicy struct {
+	Type            string             `json:"type"`
+	ResourceWeights map[string]float64 `json:"resourceWeights"`
 }

--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -598,7 +598,10 @@ func getPartitions(w http.ResponseWriter, r *http.Request) {
 		capacityInfo.Capacity = partitionContext.GetTotalPartitionResource().DAOString()
 		capacityInfo.UsedCapacity = partitionContext.GetAllocatedResource().DAOString()
 		partitionInfo.Capacity = capacityInfo
-		partitionInfo.NodeSortingPolicy = partitionContext.GetNodeSortingPolicy().String()
+		partitionInfo.NodeSortingPolicy = dao.NodeSortingPolicy{
+			Type:            partitionContext.GetNodeSortingPolicyType().String(),
+			ResourceWeights: partitionContext.GetNodeSortingResourceWeights(),
+		}
 
 		appList := partitionContext.GetApplications()
 		appList = append(appList, partitionContext.GetCompletedApplications()...)

--- a/pkg/webservice/handlers_test.go
+++ b/pkg/webservice/handlers_test.go
@@ -808,7 +808,9 @@ func TestPartitions(t *testing.T) {
 	assert.Assert(t, cs["default"] != nil)
 	assert.Equal(t, cs["default"].ClusterID, "rm-123")
 	assert.Equal(t, cs["default"].Name, "default")
-	assert.Equal(t, cs["default"].NodeSortingPolicy, "fair")
+	assert.Equal(t, cs["default"].NodeSortingPolicy.Type, "fair")
+	assert.Equal(t, cs["default"].NodeSortingPolicy.ResourceWeights["vcore"], 1.0)
+	assert.Equal(t, cs["default"].NodeSortingPolicy.ResourceWeights["memory"], 1.0)
 	assert.Equal(t, cs["default"].Applications["total"], 8)
 	assert.Equal(t, cs["default"].Applications[objects.New.String()], 1)
 	assert.Equal(t, cs["default"].Applications[objects.Accepted.String()], 1)
@@ -823,7 +825,9 @@ func TestPartitions(t *testing.T) {
 	assert.Assert(t, cs["gpu"] != nil)
 	assert.Equal(t, cs["gpu"].ClusterID, "rm-123")
 	assert.Equal(t, cs["gpu"].Name, "gpu")
-	assert.Equal(t, cs["gpu"].NodeSortingPolicy, "fair")
+	assert.Equal(t, cs["default"].NodeSortingPolicy.Type, "fair")
+	assert.Equal(t, cs["default"].NodeSortingPolicy.ResourceWeights["vcore"], 1.0)
+	assert.Equal(t, cs["default"].NodeSortingPolicy.ResourceWeights["memory"], 1.0)
 	assert.Equal(t, cs["gpu"].Applications["total"], 0)
 }
 


### PR DESCRIPTION
### What is this PR for?
Show the resource weighting by restful APIs. This PR will break the restful APIs.
- it should be fine since next release is 1.0.0
- I will file another PR to update docs
- our web repo does not use `/ws/v1/partitions`

### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [x] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-859

### How should this be tested?

### Screenshots (if appropriate)

<img width="250" alt="截圖 2021-09-23 下午5 49 02" src="https://user-images.githubusercontent.com/6234750/134487460-ebe0a237-cf07-4909-b1ef-be9b5f961322.png">


### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
