### PR TITLE
[YUNIKORN-862] ClusterContext#removePartition ought to use write lock

### DIFF
--- a/pkg/scheduler/context.go
+++ b/pkg/scheduler/context.go
@@ -525,8 +525,8 @@ func (cc *ClusterContext) NeedPreemption() bool {
 
 // Callback from the partition manager to finalise the removal of the partition
 func (cc *ClusterContext) removePartition(partitionName string) {
-	cc.RLock()
-	defer cc.RUnlock()
+	cc.Lock()
+	defer cc.Unlock()
 
 	delete(cc.partitions, partitionName)
 }


### PR DESCRIPTION
… instead of read lock

### What is this PR for?
the delete operation is a kind of write operation, so it should use write lock.


### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-862

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
