### PR TITLE
[YUNIKORN-839]getNodesUtilJSON is broken

### DIFF
--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -350,9 +350,11 @@ func getNodesUtilJSON(partition *scheduler.PartitionContext, name string) *dao.N
 	mapResult := make([]int, 10)
 	mapName := make([][]string, 10)
 	var v float64
-	var resourceExist = true
 	var nodeUtil []*dao.NodeUtilDAOInfo
+	resourceExist := true
 	for _, node := range partition.GetNodes() {
+		resourceExist = true
+		// check resource exist or not
 		total := node.GetCapacity()
 		if total.Resources[name] <= 0 {
 			resourceExist = false
@@ -361,6 +363,7 @@ func getNodesUtilJSON(partition *scheduler.PartitionContext, name string) *dao.N
 		if _, ok := resourceAllocated.Resources[name]; !ok {
 			resourceExist = false
 		}
+		// if resource exist in node, record the bucket it should go
 		if resourceExist {
 			v = float64(resources.CalculateAbsUsedCapacity(total, resourceAllocated).Resources[name])
 			idx := int(math.Dim(math.Ceil(v/10), 1))
@@ -368,24 +371,14 @@ func getNodesUtilJSON(partition *scheduler.PartitionContext, name string) *dao.N
 			mapName[idx] = append(mapName[idx], node.NodeID)
 		}
 	}
+	// put number of nodes and node name to different buckets
 	for k := 0; k < 10; k++ {
-		if resourceExist {
-			util := &dao.NodeUtilDAOInfo{
-				BucketName: fmt.Sprintf("%d", k*10) + "-" + fmt.Sprintf("%d", (k+1)*10) + "%",
-				NumOfNodes: int64(mapResult[k]),
-				NodeNames:  mapName[k],
-			}
-			nodeUtil = append(nodeUtil, util)
-		} else {
-			util := &dao.NodeUtilDAOInfo{
-				BucketName: fmt.Sprintf("%d", k*10) + "-" + fmt.Sprintf("%d", (k+1)*10) + "%",
-				NumOfNodes: int64(-1),
-				NodeNames:  []string{"N/A"},
-			}
-			nodeUtil = append(nodeUtil, util)
+		util := &dao.NodeUtilDAOInfo{
+			BucketName: fmt.Sprintf("%d", k*10) + "-" + fmt.Sprintf("%d", (k+1)*10) + "%",
+			NumOfNodes: int64(mapResult[k]),
+			NodeNames:  mapName[k],
 		}
-		mapResult[k] = 0
-		mapName[k] = []string{}
+		nodeUtil = append(nodeUtil, util)
 	}
 	return &dao.NodesUtilDAOInfo{
 		ResourceType: name,

--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -351,9 +351,8 @@ func getNodesUtilJSON(partition *scheduler.PartitionContext, name string) *dao.N
 	mapName := make([][]string, 10)
 	var v float64
 	var nodeUtil []*dao.NodeUtilDAOInfo
-	resourceExist := true
 	for _, node := range partition.GetNodes() {
-		resourceExist = true
+		resourceExist := true
 		// check resource exist or not
 		total := node.GetCapacity()
 		if total.Resources[name] <= 0 {

--- a/pkg/webservice/handlers_test.go
+++ b/pkg/webservice/handlers_test.go
@@ -702,12 +702,12 @@ func ContainsObj(slice interface{}, contains interface{}) bool {
 
 func TestGetNodesUtilJSON(t *testing.T) {
 	configs.MockSchedulerConfigByData([]byte(configDefault))
-	schedulerContext, err := scheduler.NewClusterContext(rmID, policyGroup)
+	context, err := scheduler.NewClusterContext(rmID, policyGroup)
 	assert.NilError(t, err, "Error when load schedulerContext from config")
-	assert.Equal(t, 1, len(schedulerContext.GetPartitionMapClone()))
+	assert.Equal(t, 1, len(context.GetPartitionMapClone()))
 	// Check test partition
 	partitionName := common.GetNormalizedPartitionName("default", rmID)
-	partition := schedulerContext.GetPartition(partitionName)
+	partition := context.GetPartition(partitionName)
 	assert.Equal(t, partitionName, partition.Name)
 
 	// create test application

--- a/pkg/webservice/handlers_test.go
+++ b/pkg/webservice/handlers_test.go
@@ -702,15 +702,14 @@ func ContainsObj(slice interface{}, contains interface{}) bool {
 
 func TestGetNodesUtilJSON(t *testing.T) {
 	configs.MockSchedulerConfigByData([]byte(configDefault))
-	var err error
-	schedulerContext, err = scheduler.NewClusterContext(rmID, policyGroup)
+	schedulerContext, err := scheduler.NewClusterContext(rmID, policyGroup)
 	assert.NilError(t, err, "Error when load schedulerContext from config")
 	assert.Equal(t, 1, len(schedulerContext.GetPartitionMapClone()))
-
 	// Check test partition
 	partitionName := common.GetNormalizedPartitionName("default", rmID)
 	partition := schedulerContext.GetPartition(partitionName)
 	assert.Equal(t, partitionName, partition.Name)
+
 	// create test application
 	appID := "app1"
 	app := newApplication(appID, partitionName, queueName, rmID)
@@ -719,13 +718,15 @@ func TestGetNodesUtilJSON(t *testing.T) {
 
 	// create test nodes
 	nodeRes := resources.NewResourceFromMap(map[string]resources.Quantity{resources.MEMORY: 1000, resources.VCORE: 1000}).ToProto()
+	nodeRes2 := resources.NewResourceFromMap(map[string]resources.Quantity{resources.MEMORY: 1000, resources.VCORE: 1000, "GPU": 10}).ToProto()
 	node1ID := "node-1"
 	node1 := objects.NewNode(&si.NodeInfo{NodeID: node1ID, SchedulableResource: nodeRes})
 	node2ID := "node-2"
-	node2 := objects.NewNode(&si.NodeInfo{NodeID: node2ID, SchedulableResource: nodeRes})
+	node2 := objects.NewNode(&si.NodeInfo{NodeID: node2ID, SchedulableResource: nodeRes2})
+
 	// create test allocations
 	resAlloc1 := resources.NewResourceFromMap(map[string]resources.Quantity{resources.MEMORY: 500, resources.VCORE: 300})
-	resAlloc2 := resources.NewResourceFromMap(map[string]resources.Quantity{resources.MEMORY: 300, resources.VCORE: 500})
+	resAlloc2 := resources.NewResourceFromMap(map[string]resources.Quantity{resources.MEMORY: 300, resources.VCORE: 500, "GPU": 5})
 	ask1 := &objects.AllocationAsk{
 		AllocationKey:     "alloc-1",
 		QueueName:         queueName,
@@ -748,9 +749,11 @@ func TestGetNodesUtilJSON(t *testing.T) {
 	// get nodes utilization
 	res1 := getNodesUtilJSON(partition, resources.MEMORY)
 	res2 := getNodesUtilJSON(partition, resources.VCORE)
+	res3 := getNodesUtilJSON(partition, "GPU")
 	resNon := getNodesUtilJSON(partition, "non-exist")
 	subres1 := res1.NodesUtil
 	subres2 := res2.NodesUtil
+	subres3 := res3.NodesUtil
 	subresNon := resNon.NodesUtil
 
 	assert.Equal(t, res1.ResourceType, resources.MEMORY)
@@ -765,9 +768,13 @@ func TestGetNodesUtilJSON(t *testing.T) {
 	assert.Equal(t, subres2[2].NodeNames[0], node1ID)
 	assert.Equal(t, subres2[4].NodeNames[0], node2ID)
 
+	assert.Equal(t, res3.ResourceType, "GPU")
+	assert.Equal(t, subres3[4].NumOfNodes, int64(1))
+	assert.Equal(t, subres3[4].NodeNames[0], node2ID)
+
 	assert.Equal(t, resNon.ResourceType, "non-exist")
-	assert.Equal(t, subresNon[0].NumOfNodes, int64(-1))
-	assert.Equal(t, subresNon[0].NodeNames[0], "N/A")
+	assert.Equal(t, subresNon[0].NumOfNodes, int64(0))
+	assert.Equal(t, len(subresNon[0].NodeNames), 0)
 }
 
 func addAndConfirmApplicationExists(t *testing.T, partitionName string, partition *scheduler.PartitionContext, appName string) *objects.Application {


### PR DESCRIPTION
### What is this PR for?
Leverage resourceExist flag only in first for loop, and remove the resourceExist flag check in second for loop .
Also simplify the output, we get same output when input resource type isn't exist and the utilization bucket get no node.
Both situation return 0 number of node, and nodes Name is Null.

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
(https://issues.apache.org/jira/browse/YUNIKORN-839)

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
