### PR TITLE
[YUNIKORN-948] Data race in TestGetSchedulerHealthStatusContext

### DIFF
--- a/pkg/scheduler/health_checker_test.go
+++ b/pkg/scheduler/health_checker_test.go
@@ -95,9 +95,10 @@ func TestGetSchedulerHealthStatusContext(t *testing.T) {
 
 	// add the allocation to the app as well
 	part := schedulerContext.partitions[partName]
-	app := newApplication("appID", partName, "queue")
+	app := newApplication("appID", partName, "root.default")
 	app.AddAllocation(alloc)
-	part.applications["appID"] = app
+	err = part.AddApplication(app)
+	assert.NilError(t, err, "Could not add application")
 	healthInfo = GetSchedulerHealthStatus(schedulerMetrics, schedulerContext)
 	assert.Assert(t, healthInfo.HealthChecks[9].Succeeded, "The orphan allocation check on the node should be successful")
 


### PR DESCRIPTION
### What is this PR for?
Directly manipulating a map in the testcase TestGetSchedulerHealthStatusContext might result in a data race and the test fails.  


### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-948

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
