### PR TITLE
[YUNIKORN-950] Add missing HTTP routes regarding statedump feature

### DIFF
--- a/pkg/webservice/routes.go
+++ b/pkg/webservice/routes.go
@@ -182,6 +182,18 @@ var webRoutes = routes{
 		"/ws/v1/periodicstatedump/{switch}/{periodSeconds}",
 		handlePeriodicStateDump,
 	},
+	route{
+		"Scheduler",
+		"PUT",
+		"/ws/v1/periodicstatedump/{switch}/",
+		handlePeriodicStateDump,
+	},
+	route{
+		"Scheduler",
+		"PUT",
+		"/ws/v1/periodicstatedump/",
+		handlePeriodicStateDump,
+	},
 	// endpoint to retrieve CPU, Memory profiling data,
 	// this works with pprof tool. By default, pprof endpoints
 	// are only registered to http.DefaultServeMux. Here, we


### PR DESCRIPTION
### What is this PR for?
Add missing paths `/ws/v1/periodicstatedump/{switch}/` and `/ws/v1/periodicstatedump/` to the list of routes, otherwise we receive 404.


### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-950

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
