### PR TITLE
[YUNIKORN-963] Fix calculateNodesResourceUsage when node's resource is overallocated

### DIFF
--- a/pkg/scheduler/partition.go
+++ b/pkg/scheduler/partition.go
@@ -1155,7 +1155,8 @@ func (pc *PartitionContext) calculateNodesResourceUsage() map[string][]int {
 		for name, total := range node.GetCapacity().Resources {
 			if float64(total) > 0 {
 				resourceAllocated := float64(node.GetAllocatedResource().Resources[name])
-				v := resourceAllocated / float64(total)
+				// Consider over-allocated node as 100% utilized.
+				v := math.Min(resourceAllocated / float64(total), 1)
 				idx := int(math.Dim(math.Ceil(v*10), 1))
 				if dist, ok := mapResult[name]; !ok {
 					newDist := make([]int, 10)

--- a/pkg/scheduler/partition.go
+++ b/pkg/scheduler/partition.go
@@ -1156,7 +1156,7 @@ func (pc *PartitionContext) calculateNodesResourceUsage() map[string][]int {
 			if float64(total) > 0 {
 				resourceAllocated := float64(node.GetAllocatedResource().Resources[name])
 				// Consider over-allocated node as 100% utilized.
-				v := math.Min(resourceAllocated / float64(total), 1)
+				v := math.Min(resourceAllocated/float64(total), 1)
 				idx := int(math.Dim(math.Ceil(v*10), 1))
 				if dist, ok := mapResult[name]; !ok {
 					newDist := make([]int, 10)

--- a/pkg/scheduler/partition_test.go
+++ b/pkg/scheduler/partition_test.go
@@ -373,14 +373,14 @@ func TestCalculateNodesResourceUsage(t *testing.T) {
 	alloc := objects.NewAllocation(allocID, nodeID1, newAllocationAsk("key", "appID", occupiedResources))
 	node.AddAllocation(alloc)
 	usageMap := partition.calculateNodesResourceUsage()
-	assert.Assert(t, node.GetAvailableResource().Resources["first"] == resources.Quantity(50))
+	assert.Equal(t, node.GetAvailableResource().Resources["first"], resources.Quantity(50))
 	assert.Equal(t, usageMap["first"][4], 1)
 
 	occupiedResources = resources.NewResourceFromMap(map[string]resources.Quantity{"first": 50})
 	alloc = objects.NewAllocation(allocID, nodeID1, newAllocationAsk("key", "appID", occupiedResources))
 	node.AddAllocation(alloc)
 	usageMap = partition.calculateNodesResourceUsage()
-	assert.Assert(t, node.GetAvailableResource().Resources["first"] == resources.Quantity(0))
+	assert.Equal(t, node.GetAvailableResource().Resources["first"], resources.Quantity(0))
 	assert.Equal(t, usageMap["first"][9], 1)
 
 	newCapacity := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 80})

--- a/pkg/scheduler/partition_test.go
+++ b/pkg/scheduler/partition_test.go
@@ -373,20 +373,20 @@ func TestCalculateNodesResourceUsage(t *testing.T) {
 	alloc := objects.NewAllocation(allocID, nodeID1, newAllocationAsk("key", "appID", occupiedResources))
 	node.AddAllocation(alloc)
 	usageMap := partition.calculateNodesResourceUsage()
-	assert.Assert(t, node.GetAvailableResource().Resources["first"] == 50)
+	assert.Assert(t, node.GetAvailableResource().Resources["first"] == resources.Quantity(50))
 	assert.Equal(t, usageMap["first"][4], 1)
 
 	occupiedResources = resources.NewResourceFromMap(map[string]resources.Quantity{"first": 50})
 	alloc = objects.NewAllocation(allocID, nodeID1, newAllocationAsk("key", "appID", occupiedResources))
 	node.AddAllocation(alloc)
 	usageMap = partition.calculateNodesResourceUsage()
-	assert.Assert(t, node.GetAvailableResource().Resources["first"] == 0)
+	assert.Assert(t, node.GetAvailableResource().Resources["first"] == resources.Quantity(0))
 	assert.Equal(t, usageMap["first"][9], 1)
 
 	newCapacity := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 80})
 	node.SetCapacity(newCapacity)
 	usageMap = partition.calculateNodesResourceUsage()
-	assert.Assert(t, node.GetAvailableResource().HasNegativeValue() == true)
+	assert.Assert(t, node.GetAvailableResource().HasNegativeValue())
 	assert.Equal(t, usageMap["first"][9], 1)
 }
 

--- a/pkg/scheduler/partition_test.go
+++ b/pkg/scheduler/partition_test.go
@@ -366,7 +366,8 @@ func TestCalculateNodesResourceUsage(t *testing.T) {
 	assert.NilError(t, err, "partition create failed")
 	oldCapacity := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 100})
 	node := newNodeMaxResource(nodeID1, oldCapacity)
-	partition.AddNode(node, nil)
+	err = partition.AddNode(node, nil)
+	assert.NilError(t, err)
 
 	occupiedResources := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 50})
 	alloc := objects.NewAllocation(allocID, nodeID1, newAllocationAsk("key", "appID", occupiedResources))

--- a/pkg/scheduler/partition_test.go
+++ b/pkg/scheduler/partition_test.go
@@ -361,6 +361,34 @@ func TestRemoveNodeWithPlaceholders(t *testing.T) {
 	assert.Equal(t, 0, len(ph.Releases), "placeholder should have no releases linked anymore")
 }
 
+func TestCalculateNodesResourceUsage(t *testing.T) {
+	partition, err := newBasePartition()
+	assert.NilError(t, err, "partition create failed")
+	oldCapacity := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 100})
+	node := newNodeMaxResource(nodeID1, oldCapacity)
+	partition.AddNode(node, nil)
+
+	occupiedResources := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 50})
+	alloc := objects.NewAllocation(allocID, nodeID1, newAllocationAsk("key", "appID", occupiedResources))
+	node.AddAllocation(alloc)
+	usageMap := partition.calculateNodesResourceUsage()
+	assert.Assert(t, node.GetAvailableResource().Resources["first"] == 50)
+	assert.Equal(t, usageMap["first"][4], 1)
+
+	occupiedResources = resources.NewResourceFromMap(map[string]resources.Quantity{"first": 50})
+	alloc = objects.NewAllocation(allocID, nodeID1, newAllocationAsk("key", "appID", occupiedResources))
+	node.AddAllocation(alloc)
+	usageMap = partition.calculateNodesResourceUsage()
+	assert.Assert(t, node.GetAvailableResource().Resources["first"] == 0)
+	assert.Equal(t, usageMap["first"][9], 1)
+
+	newCapacity := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 80})
+	node.SetCapacity(newCapacity)
+	usageMap = partition.calculateNodesResourceUsage()
+	assert.Assert(t, node.GetAvailableResource().HasNegativeValue() == true)
+	assert.Equal(t, usageMap["first"][9], 1)
+}
+
 // test with a replacement of a placeholder: placeholder on the removed node, real on the 2nd node
 func TestRemoveNodeWithReplacement(t *testing.T) {
 	partition, err := newBasePartition()


### PR DESCRIPTION
### What is this PR for?

When a node resource is over-allocated `calculateNodesResourceUsage` crashes as it does not expect any resource to be over-allocated. If a node is over-allocated because of any reason, it should be handled gracefully.
So this PR is updating `calculateNodesResourceUsage` so that it considers an over-allocated node as 100% used.

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-963

### How should this be tested?
Added UT
