### PR TITLE
YUNIKORN-462: Streamline core to shim update on allocation change

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ go 1.16
 
 require (
 	github.com/HdrHistogram/hdrhistogram-go v1.0.1 // indirect
-	github.com/apache/incubator-yunikorn-scheduler-interface v0.11.1-0.20220218043513-e19a1b0c381f
+	github.com/apache/incubator-yunikorn-scheduler-interface v0.0.0-20220218043513-e19a1b0c381f
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/google/btree v1.0.1
 	github.com/google/uuid v1.2.0

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ go 1.16
 
 require (
 	github.com/HdrHistogram/hdrhistogram-go v1.0.1 // indirect
-	github.com/apache/incubator-yunikorn-scheduler-interface v0.0.0-20220214023648-0de002ac41d3
+	github.com/apache/incubator-yunikorn-scheduler-interface v0.11.1-0.20220218043513-e19a1b0c381f
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/google/btree v1.0.1
 	github.com/google/uuid v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,8 @@ github.com/HdrHistogram/hdrhistogram-go v1.0.1 h1:GX8GAYDuhlFQnI2fRDHQhTlkHMz8bE
 github.com/HdrHistogram/hdrhistogram-go v1.0.1/go.mod h1:BWJ+nMSHY3L41Zj7CA3uXnloDp7xxV0YvstAE7nKTaM=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
-github.com/apache/incubator-yunikorn-scheduler-interface v0.11.1-0.20220218043513-e19a1b0c381f h1:eiN8M+y9/Wwy2L+bm519wRmDSEqKEqfedNXwYZaUFVU=
-github.com/apache/incubator-yunikorn-scheduler-interface v0.11.1-0.20220218043513-e19a1b0c381f/go.mod h1:3tRnilDaaJISjaG8REYnsnRsfr+NymQ02Yjs983zRYY=
+github.com/apache/incubator-yunikorn-scheduler-interface v0.0.0-20220218043513-e19a1b0c381f h1:IJKl13BYc++ULbYQMQXhNqGm+LZbp5Gg0Jeq76mSVAo=
+github.com/apache/incubator-yunikorn-scheduler-interface v0.0.0-20220218043513-e19a1b0c381f/go.mod h1:3tRnilDaaJISjaG8REYnsnRsfr+NymQ02Yjs983zRYY=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,8 @@ github.com/HdrHistogram/hdrhistogram-go v1.0.1 h1:GX8GAYDuhlFQnI2fRDHQhTlkHMz8bE
 github.com/HdrHistogram/hdrhistogram-go v1.0.1/go.mod h1:BWJ+nMSHY3L41Zj7CA3uXnloDp7xxV0YvstAE7nKTaM=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
-github.com/apache/incubator-yunikorn-scheduler-interface v0.0.0-20220214023648-0de002ac41d3 h1:J8pawaZ96w6B4HYt4wIKZJJfWijlc0kTtRrqcLtQi9g=
-github.com/apache/incubator-yunikorn-scheduler-interface v0.0.0-20220214023648-0de002ac41d3/go.mod h1:3tRnilDaaJISjaG8REYnsnRsfr+NymQ02Yjs983zRYY=
+github.com/apache/incubator-yunikorn-scheduler-interface v0.11.1-0.20220218043513-e19a1b0c381f h1:eiN8M+y9/Wwy2L+bm519wRmDSEqKEqfedNXwYZaUFVU=
+github.com/apache/incubator-yunikorn-scheduler-interface v0.11.1-0.20220218043513-e19a1b0c381f/go.mod h1:3tRnilDaaJISjaG8REYnsnRsfr+NymQ02Yjs983zRYY=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/pkg/rmproxy/rmevent/events.go
+++ b/pkg/rmproxy/rmevent/events.go
@@ -86,11 +86,6 @@ type RMRejectedAllocationAskEvent struct {
 type RMReleaseAllocationEvent struct {
 	RmID                string
 	ReleasedAllocations []*si.AllocationRelease
-}
-
-type RMReleaseAllocationSyncEvent struct {
-	RmID                string
-	ReleasedAllocations []*si.AllocationRelease
 	Channel             chan *Result
 }
 

--- a/pkg/rmproxy/rmevent/events.go
+++ b/pkg/rmproxy/rmevent/events.go
@@ -65,10 +65,10 @@ type Result struct {
 }
 
 // Outgoing events from the scheduler to the RM
-// These events communicate the response to the RMUpdateRequestEvent
 type RMNewAllocationsEvent struct {
 	RmID        string
 	Allocations []*si.Allocation
+	Channel     chan *Result
 }
 
 type RMApplicationUpdateEvent struct {
@@ -86,6 +86,12 @@ type RMRejectedAllocationAskEvent struct {
 type RMReleaseAllocationEvent struct {
 	RmID                string
 	ReleasedAllocations []*si.AllocationRelease
+}
+
+type RMReleaseAllocationSyncEvent struct {
+	RmID                string
+	ReleasedAllocations []*si.AllocationRelease
+	Channel             chan *Result
 }
 
 type RMReleaseAllocationAskEvent struct {

--- a/pkg/rmproxy/rmproxy.go
+++ b/pkg/rmproxy/rmproxy.go
@@ -147,10 +147,8 @@ func (rmp *RMProxy) processRMReleaseAllocationEvent(event *rmevent.RMReleaseAllo
 	metrics.GetSchedulerMetrics().AddReleasedContainers(len(event.ReleasedAllocations))
 
 	// Done, notify channel
-	if event.Channel != nil {
-		event.Channel <- &rmevent.Result{
-			Succeeded: true,
-		}
+	event.Channel <- &rmevent.Result{
+		Succeeded: true,
 	}
 }
 

--- a/pkg/rmproxy/rmproxy.go
+++ b/pkg/rmproxy/rmproxy.go
@@ -108,7 +108,7 @@ func (rmp *RMProxy) processAllocationUpdateEvent(event *rmevent.RMNewAllocations
 	// Done, notify channel
 	event.Channel <- &rmevent.Result{
 		Succeeded: true,
-		Reason:	fmt.Sprintf("no. of allocations: #{allocationsCount}"),
+		Reason:    fmt.Sprintf("no. of allocations: #{allocationsCount}"),
 	}
 }
 
@@ -156,7 +156,7 @@ func (rmp *RMProxy) processRMReleaseAllocationEvent(event *rmevent.RMReleaseAllo
 	// Done, notify channel
 	event.Channel <- &rmevent.Result{
 		Succeeded: true,
-		Reason:	fmt.Sprintf("no. of allocations: #{allocationsCount}"),
+		Reason:    fmt.Sprintf("no. of allocations: #{allocationsCount}"),
 	}
 }
 

--- a/pkg/rmproxy/rmproxy.go
+++ b/pkg/rmproxy/rmproxy.go
@@ -21,6 +21,7 @@ package rmproxy
 import (
 	"fmt"
 	"reflect"
+	"strconv"
 	"sync"
 
 	"go.uber.org/zap"
@@ -108,7 +109,7 @@ func (rmp *RMProxy) processAllocationUpdateEvent(event *rmevent.RMNewAllocations
 	// Done, notify channel
 	event.Channel <- &rmevent.Result{
 		Succeeded: true,
-		Reason:    fmt.Sprintf("no. of allocations: #{allocationsCount}"),
+		Reason:    "no. of allocations: " + strconv.Itoa(allocationsCount),
 	}
 }
 
@@ -156,7 +157,7 @@ func (rmp *RMProxy) processRMReleaseAllocationEvent(event *rmevent.RMReleaseAllo
 	// Done, notify channel
 	event.Channel <- &rmevent.Result{
 		Succeeded: true,
-		Reason:    fmt.Sprintf("no. of allocations: #{allocationsCount}"),
+		Reason:    "no. of allocations: " + strconv.Itoa(allocationsCount),
 	}
 }
 

--- a/pkg/scheduler/context.go
+++ b/pkg/scheduler/context.go
@@ -830,8 +830,7 @@ func (cc *ClusterContext) notifyRMAllocationReleasedSynchronously(rmID string, r
 			UUID:            alloc.UUID,
 			TerminationType: terminationType,
 			Message:         message,
-			Allocationkey:   alloc.AllocationKey,
-			UpdateCache:     true,
+			AllocationKey:   alloc.AllocationKey,
 		})
 	}
 

--- a/pkg/scheduler/context.go
+++ b/pkg/scheduler/context.go
@@ -32,7 +32,6 @@ import (
 	"github.com/apache/incubator-yunikorn-core/pkg/handler"
 	"github.com/apache/incubator-yunikorn-core/pkg/log"
 	"github.com/apache/incubator-yunikorn-core/pkg/metrics"
-	"github.com/apache/incubator-yunikorn-core/pkg/plugins"
 	"github.com/apache/incubator-yunikorn-core/pkg/rmproxy/rmevent"
 	"github.com/apache/incubator-yunikorn-core/pkg/scheduler/objects"
 	siCommon "github.com/apache/incubator-yunikorn-scheduler-interface/lib/go/common"
@@ -744,46 +743,17 @@ func (cc *ClusterContext) processAskReleases(releases []*si.AllocationAskRelease
 }
 
 func (cc *ClusterContext) processAllocationReleases(releases []*si.AllocationRelease, rmID string) {
-	// TODO: the release comes from the RM and confirmed twice why do we need event + callback?
-	// See YUNIKORN-462, there are two separate communications for the same allocation
-	// between the core and the shim they should be merged into one communication.
-
-	toReleaseAllocations := make([]*si.ForgotAllocation, 0)
 	for _, toRelease := range releases {
 		partition := cc.GetPartition(toRelease.PartitionName)
 		if partition != nil {
 			allocs, confirmed := partition.removeAllocation(toRelease)
 			// notify the RM of the exact released allocations
 			if len(allocs) > 0 {
-				cc.notifyRMAllocationReleased(rmID, allocs, si.TerminationType_STOPPED_BY_RM, "allocation remove as per RM request")
-			}
-			for _, alloc := range allocs {
-				toReleaseAllocations = append(toReleaseAllocations, &si.ForgotAllocation{
-					AllocationKey: alloc.AllocationKey,
-				})
+				cc.notifyRMAllocationReleasedSynchronously(rmID, allocs, si.TerminationType_STOPPED_BY_RM, "allocation remove as per RM request")
 			}
 			// notify the RM of the confirmed allocations (placeholder swap & preemption)
 			if confirmed != nil {
 				cc.notifyRMNewAllocation(rmID, confirmed)
-			}
-		}
-	}
-
-	// if reconcile plugin is enabled, re-sync the cache now.
-	// this gives the chance for the cache to update its memory about assumed pods
-	// whenever we release an allocation, we must ensure the corresponding pod is successfully
-	// removed from external cache, otherwise predicates will run into problems.
-	if len(toReleaseAllocations) > 0 {
-		log.Logger().Debug("notify shim to forget assumed pods",
-			zap.Int("size", len(toReleaseAllocations)))
-		if rp := plugins.GetResourceManagerCallbackPlugin(); rp != nil {
-			err := rp.ReSyncSchedulerCache(&si.ReSyncSchedulerCacheArgs{
-				ForgetAllocations: toReleaseAllocations,
-			})
-			// See YUNIKORN-462: this might not be a real error so log as DEBUG
-			if err != nil {
-				log.Logger().Debug("failed to sync shim on allocation release",
-					zap.Error(err))
 			}
 		}
 	}
@@ -802,36 +772,22 @@ func (cc *ClusterContext) convertAllocations(allocations []*si.Allocation) []*ob
 // Create a RM update event to notify RM of new allocations
 // Lock free call, all updates occur via events.
 func (cc *ClusterContext) notifyRMNewAllocation(rmID string, alloc *objects.Allocation) {
-	// CLEANUP: The alloc is passed to the RM twice why do we need event + callback?
-	// See YUNIKORN-462, there are two separate communications for the same allocation
-	// between the core and the shim they should be merged into one communication.
-
-	// if reconcile plugin is enabled, re-sync the cache now.
-	// before deciding on an allocation, call the reconcile plugin to sync scheduler cache
-	// between core and shim if necessary. This is useful when running multiple allocations
-	// in parallel and need to handle inter container affinity and anti-affinity.
-	// note, this needs to happen before notifying the RM about this allocation, because
-	// the RM side needs to get its cache refreshed (via reconcile plugin) before allocating
-	// the actual container.
-	if rp := plugins.GetResourceManagerCallbackPlugin(); rp != nil {
-		if err := rp.ReSyncSchedulerCache(&si.ReSyncSchedulerCacheArgs{
-			AssumedAllocations: []*si.AssumedAllocation{
-				{
-					AllocationKey: alloc.AllocationKey,
-					NodeID:        alloc.NodeID,
-				},
-			},
-		}); err != nil {
-			log.Logger().Error("failed to sync shim on allocation",
-				zap.Error(err))
-		}
-	}
-
-	// communicate the allocation to the RM
+	c := make(chan *rmevent.Result)
+	// communicate the allocation to the RM synchronously
 	cc.rmEventHandler.HandleEvent(&rmevent.RMNewAllocationsEvent{
 		Allocations: []*si.Allocation{alloc.NewSIFromAllocation()},
 		RmID:        rmID,
+		Channel:     c,
 	})
+	// Wait from channel
+	result := <-c
+	if result.Succeeded {
+		log.Logger().Debug("Successfully synced shim on new allocation",
+			zap.String("Allocation key: ", alloc.AllocationKey))
+	} else {
+		log.Logger().Info("failed to sync shim on new allocation",
+			zap.String("Allocation key: ", alloc.AllocationKey))
+	}
 }
 
 // Create a RM update event to notify RM of released allocations
@@ -850,8 +806,38 @@ func (cc *ClusterContext) notifyRMAllocationReleased(rmID string, released []*ob
 			Message:         message,
 		})
 	}
+	cc.rmEventHandler.HandleEvent(releaseEvent)
+}
+
+// Create a RM update event to notify RM of released allocations synchronously
+// Lock free call, all updates occur via events.
+func (cc *ClusterContext) notifyRMAllocationReleasedSynchronously(rmID string, released []*objects.Allocation, terminationType si.TerminationType, message string) {
+	c := make(chan *rmevent.Result)
+	releaseEvent := &rmevent.RMReleaseAllocationSyncEvent{
+		ReleasedAllocations: make([]*si.AllocationRelease, 0),
+		RmID:                rmID,
+		Channel:             c,
+	}
+	for _, alloc := range released {
+		releaseEvent.ReleasedAllocations = append(releaseEvent.ReleasedAllocations, &si.AllocationRelease{
+			ApplicationID:   alloc.ApplicationID,
+			PartitionName:   alloc.PartitionName,
+			UUID:            alloc.UUID,
+			TerminationType: terminationType,
+			Message:         message,
+			Allocationkey:   alloc.AllocationKey,
+			UpdateCache:     true,
+		})
+	}
 
 	cc.rmEventHandler.HandleEvent(releaseEvent)
+	// Wait from channel
+	result := <-c
+	if result.Succeeded {
+		log.Logger().Debug("Successfully synced shim on released allocations")
+	} else {
+		log.Logger().Info("failed to sync shim on released allocations")
+	}
 }
 
 // Get a scheduling node based on its name from the partition.

--- a/pkg/scheduler/context.go
+++ b/pkg/scheduler/context.go
@@ -772,9 +772,6 @@ func (cc *ClusterContext) convertAllocations(allocations []*si.Allocation) []*ob
 // Create a RM update event to notify RM of new allocations
 // Lock free call, all updates occur via events.
 func (cc *ClusterContext) notifyRMNewAllocation(rmID string, alloc *objects.Allocation) {
-	if alloc == nil {
-		return
-	}
 	c := make(chan *rmevent.Result)
 	// communicate the allocation to the RM synchronously
 	cc.rmEventHandler.HandleEvent(&rmevent.RMNewAllocationsEvent{
@@ -785,8 +782,7 @@ func (cc *ClusterContext) notifyRMNewAllocation(rmID string, alloc *objects.Allo
 	// Wait from channel
 	result := <-c
 	if result.Succeeded {
-		log.Logger().Debug("Successfully synced shim on new allocation",
-			zap.String("Allocation key: ", alloc.AllocationKey))
+		log.Logger().Debug("Successfully synced shim on new allocation. response: " + result.Reason)
 	} else {
 		log.Logger().Info("failed to sync shim on new allocation",
 			zap.String("Allocation key: ", alloc.AllocationKey))
@@ -796,9 +792,6 @@ func (cc *ClusterContext) notifyRMNewAllocation(rmID string, alloc *objects.Allo
 // Create a RM update event to notify RM of released allocations
 // Lock free call, all updates occur via events.
 func (cc *ClusterContext) notifyRMAllocationReleased(rmID string, released []*objects.Allocation, terminationType si.TerminationType, message string) {
-	if len(released) == 0 {
-		return
-	}
 	c := make(chan *rmevent.Result)
 	releaseEvent := &rmevent.RMReleaseAllocationEvent{
 		ReleasedAllocations: make([]*si.AllocationRelease, 0),
@@ -820,7 +813,7 @@ func (cc *ClusterContext) notifyRMAllocationReleased(rmID string, released []*ob
 	// Wait from channel
 	result := <-c
 	if result.Succeeded {
-		log.Logger().Debug("Successfully synced shim on released allocations")
+		log.Logger().Debug("Successfully synced shim on released allocations. response: " + result.Reason)
 	} else {
 		log.Logger().Info("failed to sync shim on released allocations")
 	}

--- a/pkg/scheduler/tests/mock_rm_callback.go
+++ b/pkg/scheduler/tests/mock_rm_callback.go
@@ -41,11 +41,6 @@ func (f *MockResourceManagerCallback) Predicates(args *si.PredicatesArgs) error 
 	return nil
 }
 
-func (f *MockResourceManagerCallback) ReSyncSchedulerCache(args *si.ReSyncSchedulerCacheArgs) error {
-	// do nothing
-	return nil
-}
-
 func (f *MockResourceManagerCallback) SendEvent(events []*si.EventRecord) {
 	// do nothing
 }


### PR DESCRIPTION
### What is this PR for?
New Allocation and Release allocations events has been changed from async to synchronous communication so that shim updates its own cache immediately followed up by pod bind/delete steps. With this change, ReSyncSchedulerCache plugin doesn't have any more role to play. Hence, cleaned up the related plugin code as well.

### What type of PR is it?
* [ ] - Improvement

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-462

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
