### PR TITLE
[YUNIKORN-828]Add YuniKorn core's queue-level capacity (guaranteed, max) metrics

### DIFF
--- a/pkg/metrics/init.go
+++ b/pkg/metrics/init.go
@@ -49,8 +49,8 @@ type CoreQueueMetrics interface {
 	DecQueueApplicationsRunning()
 	SetQueueGuaranteedResourceMetrics(resourceName string, value float64)
 	SetQueueMaxResourceMetrics(resourceName string, value float64)
-	SetQueueUsedResourceMetrics(resourceName string, value float64)
-	AddQueueUsedResourceMetrics(resourceName string, value float64)
+	SetQueueAllocatedResourceMetrics(resourceName string, value float64)
+	AddQueueAllocatedResourceMetrics(resourceName string, value float64)
 	SetQueuePendingResourceMetrics(resourceName string, value float64)
 	AddQueuePendingResourceMetrics(resourceName string, value float64)
 }

--- a/pkg/metrics/queue.go
+++ b/pkg/metrics/queue.go
@@ -51,7 +51,7 @@ func InitQueueMetrics(name string) CoreQueueMetrics {
 			Namespace: Namespace,
 			Subsystem: substituteQueueName(name),
 			Name:      "queue_resource",
-			Help:      "Queue resource metrics. State of the resource includes `guaranteed`, `max`, `allocated`, `pending`, `available`.",
+			Help:      "Queue resource metrics. State of the resource includes `guaranteed`, `max`, `allocated`, `pending`.",
 		}, []string{"state", "resource"})
 
 	var queueMetricsList = []prometheus.Collector{
@@ -94,11 +94,11 @@ func (m *QueueMetrics) SetQueueMaxResourceMetrics(resourceName string, value flo
 	m.ResourceMetrics.With(prometheus.Labels{"state": "max", "resource": resourceName}).Set(value)
 }
 
-func (m *QueueMetrics) SetQueueUsedResourceMetrics(resourceName string, value float64) {
+func (m *QueueMetrics) SetQueueAllocatedResourceMetrics(resourceName string, value float64) {
 	m.ResourceMetrics.With(prometheus.Labels{"state": "allocated", "resource": resourceName}).Set(value)
 }
 
-func (m *QueueMetrics) AddQueueUsedResourceMetrics(resourceName string, value float64) {
+func (m *QueueMetrics) AddQueueAllocatedResourceMetrics(resourceName string, value float64) {
 	m.ResourceMetrics.With(prometheus.Labels{"state": "allocated", "resource": resourceName}).Add(value)
 }
 

--- a/pkg/scheduler/objects/queue.go
+++ b/pkg/scheduler/objects/queue.go
@@ -1253,8 +1253,10 @@ func (sq *Queue) SupportTaskGroup() bool {
 // updateGuaranteedResourceMetrics updates guaranteed resource metrics if this is a leaf queue.
 func (sq *Queue) updateGuaranteedResourceMetrics() {
 	if sq.isLeaf {
-		for k, v := range sq.guaranteedResource.Resources {
-			metrics.GetQueueMetrics(sq.QueuePath).SetQueueGuaranteedResourceMetrics(k, float64(v))
+		if sq.guaranteedResource != nil {
+			for k, v := range sq.guaranteedResource.Resources {
+				metrics.GetQueueMetrics(sq.QueuePath).SetQueueGuaranteedResourceMetrics(k, float64(v))
+			}
 		}
 	}
 }
@@ -1262,8 +1264,10 @@ func (sq *Queue) updateGuaranteedResourceMetrics() {
 // updateMaxResourceMetrics updates max resource metrics if this is a leaf queue.
 func (sq *Queue) updateMaxResourceMetrics() {
 	if sq.isLeaf {
-		for k, v := range sq.maxResource.Resources {
-			metrics.GetQueueMetrics(sq.QueuePath).SetQueueMaxResourceMetrics(k, float64(v))
+		if sq.maxResource != nil {
+			for k, v := range sq.maxResource.Resources {
+				metrics.GetQueueMetrics(sq.QueuePath).SetQueueMaxResourceMetrics(k, float64(v))
+			}
 		}
 	}
 }

--- a/pkg/scheduler/objects/queue.go
+++ b/pkg/scheduler/objects/queue.go
@@ -159,6 +159,9 @@ func (sq *Queue) applyTemplate(childTemplate *template.Template) {
 	// the resources in template are already checked
 	sq.guaranteedResource = childTemplate.GetGuaranteedResource()
 	sq.maxResource = childTemplate.GetMaxResource()
+	// update metrics for guaranteed and max resource
+	sq.updateGuaranteedResourceMetrics()
+	sq.updateMaxResourceMetrics()
 }
 
 // getProperties returns a copy of the properties for this queue
@@ -830,7 +833,7 @@ func (sq *Queue) IncAllocatedResource(alloc *resources.Resource, nodeReported bo
 	}
 	// all OK update this queue
 	sq.allocatedResource = newAllocated
-	sq.updateUsedResourceMetrics()
+	sq.updateAllocatedResourceMetrics()
 	return nil
 }
 
@@ -866,7 +869,7 @@ func (sq *Queue) DecAllocatedResource(alloc *resources.Resource) error {
 	}
 	// all OK update the queue
 	sq.allocatedResource = resources.Sub(sq.allocatedResource, alloc)
-	sq.updateUsedResourceMetrics()
+	sq.updateAllocatedResourceMetrics()
 	return nil
 }
 
@@ -1247,11 +1250,29 @@ func (sq *Queue) SupportTaskGroup() bool {
 	return sq.sortType == policies.FifoSortPolicy || sq.sortType == policies.StateAwarePolicy
 }
 
-// updateUsedResourceMetrics updates allocated resource metrics if this is a leaf queue.
-func (sq *Queue) updateUsedResourceMetrics() {
+// updateGuaranteedResourceMetrics updates guaranteed resource metrics if this is a leaf queue.
+func (sq *Queue) updateGuaranteedResourceMetrics() {
+	if sq.isLeaf {
+		for k, v := range sq.guaranteedResource.Resources {
+			metrics.GetQueueMetrics(sq.QueuePath).SetQueueGuaranteedResourceMetrics(k, float64(v))
+		}
+	}
+}
+
+// updateMaxResourceMetrics updates max resource metrics if this is a leaf queue.
+func (sq *Queue) updateMaxResourceMetrics() {
+	if sq.isLeaf {
+		for k, v := range sq.maxResource.Resources {
+			metrics.GetQueueMetrics(sq.QueuePath).SetQueueMaxResourceMetrics(k, float64(v))
+		}
+	}
+}
+
+// updateAllocatedResourceMetrics updates allocated resource metrics if this is a leaf queue.
+func (sq *Queue) updateAllocatedResourceMetrics() {
 	if sq.isLeaf {
 		for k, v := range sq.allocatedResource.Resources {
-			metrics.GetQueueMetrics(sq.QueuePath).SetQueueUsedResourceMetrics(k, float64(v))
+			metrics.GetQueueMetrics(sq.QueuePath).SetQueueAllocatedResourceMetrics(k, float64(v))
 		}
 	}
 }


### PR DESCRIPTION
### What is this PR for?

Queue-level capacity metrics (guaranteed resource, max resource) are not implemented in code.
Users need to adjust the capacity threshold manually from any monitoring dashboard if their queue capacity changes.
It is hard for users to evaluate and demonstrate historical usage trend. Not a small amount of manual work is needed by users or dev ops.

### What type of PR is it?
* [ ] - Bug Fix
* [X] - Improvement
* [X] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?

https://issues.apache.org/jira/browse/YUNIKORN-828

### How should this be tested?

Existing test coverage

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
