### PR TITLE
[YUNIKORN-960] Expose cluster utilization info in new REST calls

### DIFF
--- a/pkg/webservice/dao/partition_info.go
+++ b/pkg/webservice/dao/partition_info.go
@@ -37,6 +37,7 @@ type PartitionInfo struct {
 type PartitionCapacity struct {
 	Capacity     string `json:"capacity"`
 	UsedCapacity string `json:"usedCapacity"`
+	Utilization  string `json:"utilization"`
 }
 
 type NodeInfo struct {

--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -670,8 +670,11 @@ func getPartitionInfoDAO(lists map[string]*scheduler.PartitionContext) []*dao.Pa
 		partitionInfo.LastStateTransitionTime = partitionContext.GetStateTime().String()
 
 		capacityInfo := dao.PartitionCapacity{}
-		capacityInfo.Capacity = partitionContext.GetTotalPartitionResource().DAOString()
-		capacityInfo.UsedCapacity = partitionContext.GetAllocatedResource().DAOString()
+		capacity := partitionContext.GetTotalPartitionResource()
+		usedCapacity := partitionContext.GetAllocatedResource()
+		capacityInfo.Capacity = capacity.DAOString()
+		capacityInfo.UsedCapacity = usedCapacity.DAOString()
+		capacityInfo.Utilization = resources.CalculateAbsUsedCapacity(capacity, usedCapacity).DAOString()
 		partitionInfo.Capacity = capacityInfo
 		partitionInfo.NodeSortingPolicy = dao.NodeSortingPolicy{
 			Type:            partitionContext.GetNodeSortingPolicyType().String(),

--- a/pkg/webservice/handlers_test.go
+++ b/pkg/webservice/handlers_test.go
@@ -835,6 +835,35 @@ func TestPartitions(t *testing.T) {
 
 	NewWebApp(schedulerContext, nil)
 
+	// create test nodes
+	nodeRes := resources.NewResourceFromMap(map[string]resources.Quantity{resources.MEMORY: 500, resources.VCORE: 500}).ToProto()
+	node1ID := "node-1"
+	node1 := objects.NewNode(&si.NodeInfo{NodeID: node1ID, SchedulableResource: nodeRes})
+	node2ID := "node-2"
+	node2 := objects.NewNode(&si.NodeInfo{NodeID: node2ID, SchedulableResource: nodeRes})
+
+	// create test allocations
+	resAlloc1 := resources.NewResourceFromMap(map[string]resources.Quantity{resources.MEMORY: 100, resources.VCORE: 400})
+	resAlloc2 := resources.NewResourceFromMap(map[string]resources.Quantity{resources.MEMORY: 200, resources.VCORE: 300})
+	ask1 := &objects.AllocationAsk{
+		AllocationKey:     "alloc-1",
+		QueueName:         queueName,
+		ApplicationID:     app6.ApplicationID,
+		AllocatedResource: resAlloc1,
+	}
+	ask2 := &objects.AllocationAsk{
+		AllocationKey:     "alloc-2",
+		QueueName:         queueName,
+		ApplicationID:     app3.ApplicationID,
+		AllocatedResource: resAlloc2,
+	}
+	allocs := []*objects.Allocation{objects.NewAllocation("alloc-1-uuid", node1ID, ask1)}
+	err = defaultPartition.AddNode(node1, allocs)
+	assert.NilError(t, err, "add node to partition should not have failed")
+	allocs = []*objects.Allocation{objects.NewAllocation("alloc-2-uuid", node2ID, ask2)}
+	err = defaultPartition.AddNode(node2, allocs)
+	assert.NilError(t, err, "add node to partition should not have failed")
+
 	var req *http.Request
 	req, err = http.NewRequest("GET", "/ws/v1/partitions", strings.NewReader(""))
 	assert.NilError(t, err, "App Handler request failed")
@@ -864,6 +893,9 @@ func TestPartitions(t *testing.T) {
 	assert.Equal(t, cs["default"].Applications[objects.Rejected.String()], 1)
 	assert.Equal(t, cs["default"].Applications[objects.Completed.String()], 1)
 	assert.Equal(t, cs["default"].Applications[objects.Failed.String()], 1)
+	assert.Equal(t, cs["default"].Capacity.Capacity, "[memory:1000 vcore:1000]")
+	assert.Equal(t, cs["default"].Capacity.UsedCapacity, "[memory:300 vcore:700]")
+	assert.Equal(t, cs["default"].Capacity.Utilization, "[memory:30 vcore:70]")
 	assert.Equal(t, cs["default"].State, "Active")
 
 	assert.Assert(t, cs["gpu"] != nil)


### PR DESCRIPTION
### What is this PR for?
Move cluster utilization info from `/ws/v1/clusters/utilization` to `/ws/v1/partitions`.


### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos

### What is the Jira issue?
* https://issues.apache.org/jira/browse/YUNIKORN-960

### How should this be tested?
Modified `handlers_test.go`

### Screenshots (if appropriate)
<img width="1473" alt="Screen Shot 2022-01-19 at 8 35 54 PM" src="https://user-images.githubusercontent.com/15059525/150274218-6911eb9c-7561-4e85-aabc-1e7a52438a06.png">


### Questions:
