### PR TITLE
[YUNIKORN-958] Expose node utilisation info in new REST calls

### DIFF
--- a/pkg/scheduler/objects/node.go
+++ b/pkg/scheduler/objects/node.go
@@ -239,6 +239,27 @@ func (sn *Node) GetAvailableResource() *resources.Resource {
 	return sn.availableResource.Clone()
 }
 
+// Get the utilized resource on this node.
+func (sn *Node) GetUtilizedResource() *resources.Resource {
+	total := sn.GetCapacity()
+	resourceAllocated := sn.GetAllocatedResource()
+	m := make(map[string]bool)
+	utilizedResource := make(map[string]resources.Quantity)
+
+	for name, v := range total.Resources {
+		if v > 0 {
+			m[name] = true
+		}
+	}
+
+	for name := range resourceAllocated.Resources {
+		if _, ok := m[name]; ok {
+			utilizedResource[name] = resources.CalculateAbsUsedCapacity(total, resourceAllocated).Resources[name]
+		}
+	}
+	return &resources.Resource{Resources: utilizedResource}
+}
+
 func (sn *Node) FitInNode(resRequest *resources.Resource) bool {
 	sn.RLock()
 	defer sn.RUnlock()

--- a/pkg/webservice/dao/node_info.go
+++ b/pkg/webservice/dao/node_info.go
@@ -31,6 +31,7 @@ type NodeDAOInfo struct {
 	Allocated   string               `json:"allocated"`
 	Occupied    string               `json:"occupied"`
 	Available   string               `json:"available"`
+	Utilized    string               `json:"utilized"`
 	Allocations []*AllocationDAOInfo `json:"allocations"`
 	Schedulable bool                 `json:"schedulable"`
 }

--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -310,6 +310,7 @@ func getNodeJSON(node *objects.Node) *dao.NodeDAOInfo {
 		Occupied:    node.GetOccupiedResource().DAOString(),
 		Allocated:   node.GetAllocatedResource().DAOString(),
 		Available:   node.GetAvailableResource().DAOString(),
+		Utilized:    node.GetUtilizedResource().DAOString(),
 		Allocations: allocations,
 		Schedulable: node.IsSchedulable(),
 	}


### PR DESCRIPTION
### What is this PR for?
Introduce a field in the output of the new REST call -- `/ws/v1/partition/{partition}/nodes` that displays % utilization.


### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* Modify `node_tests.go` to introduce new test.

### What is the Jira issue?
* https://issues.apache.org/jira/browse/YUNIKORN-958

### How should this be tested?
* `node_tests.go` (still need to implement).

### Screenshots (if appropriate)
<img width="1502" alt="Screen Shot 2022-01-14 at 2 04 17 PM" src="https://user-images.githubusercontent.com/15059525/149591690-15f78d78-87dc-4279-9943-1ece91ea6a2c.png">

### Questions:
