### PR TITLE
[YUNIKORN-958] Expose node utilisation info in new REST calls

### DIFF
--- a/pkg/scheduler/objects/node.go
+++ b/pkg/scheduler/objects/node.go
@@ -239,6 +239,20 @@ func (sn *Node) GetAvailableResource() *resources.Resource {
 	return sn.availableResource.Clone()
 }
 
+// Get the utilized resource on this node.
+func (sn *Node) GetUtilizedResource() *resources.Resource {
+	total := sn.GetCapacity()
+	resourceAllocated := sn.GetAllocatedResource()
+	utilizedResource := make(map[string]resources.Quantity)
+
+	for name := range resourceAllocated.Resources {
+		if total.Resources[name] > 0 {
+			utilizedResource[name] = resources.CalculateAbsUsedCapacity(total, resourceAllocated).Resources[name]
+		}
+	}
+	return &resources.Resource{Resources: utilizedResource}
+}
+
 func (sn *Node) FitInNode(resRequest *resources.Resource) bool {
 	sn.RLock()
 	defer sn.RUnlock()

--- a/pkg/scheduler/objects/node_test.go
+++ b/pkg/scheduler/objects/node_test.go
@@ -429,7 +429,10 @@ func TestAddAllocation(t *testing.T) {
 	if !resources.Equals(node.GetAvailableResource(), half) {
 		t.Errorf("failed to update available resources expected %v, got %v", half, node.GetAvailableResource())
 	}
-
+	expectedUtilizedResource := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 50, "second": 50})
+	if !resources.Equals(node.GetUtilizedResource(), expectedUtilizedResource) {
+		t.Errorf("failed to get utilized resources expected %v, got %v", expectedUtilizedResource, node.GetUtilizedResource())
+	}
 	// second and check calculation
 	piece := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 25, "second": 50})
 	node.AddAllocation(newAllocation(appID1, "2", nodeID1, "queue-1", piece))
@@ -443,6 +446,10 @@ func TestAddAllocation(t *testing.T) {
 	left := resources.Sub(node.GetCapacity(), piece)
 	if !resources.Equals(node.GetAvailableResource(), left) {
 		t.Errorf("failed to update available resources expected %v, got %v", left, node.GetAvailableResource())
+	}
+	expectedUtilizedResource1 := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 75, "second": 75})
+	if !resources.Equals(node.GetUtilizedResource(), expectedUtilizedResource1) {
+		t.Errorf("failed to get utilized resources expected %v, got %v", expectedUtilizedResource1, node.GetUtilizedResource())
 	}
 }
 
@@ -485,6 +492,10 @@ func TestRemoveAllocation(t *testing.T) {
 	left := resources.Sub(node.GetCapacity(), piece)
 	if !resources.Equals(node.GetAvailableResource(), left) {
 		t.Errorf("allocated resource not set correctly %v got %v", left, node.GetAvailableResource())
+	}
+	expectedUtilizedResource := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 25, "second": 25})
+	if !resources.Equals(node.GetUtilizedResource(), expectedUtilizedResource) {
+		t.Errorf("failed to get utilized resources expected %v, got %v", expectedUtilizedResource, node.GetUtilizedResource())
 	}
 }
 

--- a/pkg/webservice/dao/node_info.go
+++ b/pkg/webservice/dao/node_info.go
@@ -31,6 +31,7 @@ type NodeDAOInfo struct {
 	Allocated   string               `json:"allocated"`
 	Occupied    string               `json:"occupied"`
 	Available   string               `json:"available"`
+	Utilized    string               `json:"utilized"`
 	Allocations []*AllocationDAOInfo `json:"allocations"`
 	Schedulable bool                 `json:"schedulable"`
 }

--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -310,6 +310,7 @@ func getNodeJSON(node *objects.Node) *dao.NodeDAOInfo {
 		Occupied:    node.GetOccupiedResource().DAOString(),
 		Allocated:   node.GetAllocatedResource().DAOString(),
 		Available:   node.GetAvailableResource().DAOString(),
+		Utilized:    node.GetUtilizedResource().DAOString(),
 		Allocations: allocations,
 		Schedulable: node.IsSchedulable(),
 	}

--- a/pkg/webservice/handlers_test.go
+++ b/pkg/webservice/handlers_test.go
@@ -1164,10 +1164,12 @@ func TestGetPartitionNodes(t *testing.T) {
 			assert.Equal(t, node.NodeID, node1ID)
 			assert.Equal(t, "alloc-1", node.Allocations[0].AllocationKey)
 			assert.Equal(t, "alloc-1-uuid", node.Allocations[0].UUID)
+			assert.Equal(t, "[memory:50 vcore:30]", node.Utilized)
 		} else {
 			assert.Equal(t, node.NodeID, node2ID)
 			assert.Equal(t, "alloc-2", node.Allocations[0].AllocationKey)
 			assert.Equal(t, "alloc-2-uuid", node.Allocations[0].UUID)
+			assert.Equal(t, "[memory:30 vcore:50]", node.Utilized)
 		}
 	}
 


### PR DESCRIPTION
### What is this PR for?
Introduce a field in the output of the new REST call -- `/ws/v1/partition/{partition}/nodes` that displays % utilization.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos

### What is the Jira issue?
* https://issues.apache.org/jira/browse/YUNIKORN-958

### How should this be tested?
Modified `node_test.go` to include utilized resource checks.

### Screenshots (if appropriate)
<img width="1502" alt="Screen Shot 2022-01-14 at 2 04 17 PM" src="https://user-images.githubusercontent.com/15059525/149619281-1a136fcf-b439-4c75-81e3-c6d79991c66a.png">

### Questions:
