### PR TITLE
[YUNIKORN-949] Location of the state dump file should be configurable

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	golang.org/x/text v0.3.2 // indirect
 	golang.org/x/tools v0.0.0-20200415000939-92398ad77b89 // indirect
 	google.golang.org/grpc v1.26.0
+	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 	gopkg.in/yaml.v2 v2.2.8
 	gotest.tools v2.2.0+incompatible
 	honnef.co/go/tools v0.0.1-2020.1.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -187,6 +187,8 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
+gopkg.in/natefinch/lumberjack.v2 v2.0.0 h1:1Lc07Kr7qY4U2YPouBjpCLxpiyxIVoxqXgkXLknAOE8=
+gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=

--- a/pkg/common/configs/config.go
+++ b/pkg/common/configs/config.go
@@ -46,12 +46,13 @@ type SchedulerConfig struct {
 // - a list of users specifying limits on the partition
 // - the preemption configuration for the partition
 type PartitionConfig struct {
-	Name           string
-	Queues         []QueueConfig
-	PlacementRules []PlacementRule           `yaml:",omitempty" json:",omitempty"`
-	Limits         []Limit                   `yaml:",omitempty" json:",omitempty"`
-	Preemption     PartitionPreemptionConfig `yaml:",omitempty" json:",omitempty"`
-	NodeSortPolicy NodeSortingPolicy         `yaml:",omitempty" json:",omitempty"`
+	Name              string
+	Queues            []QueueConfig
+	PlacementRules    []PlacementRule           `yaml:",omitempty" json:",omitempty"`
+	Limits            []Limit                   `yaml:",omitempty" json:",omitempty"`
+	Preemption        PartitionPreemptionConfig `yaml:",omitempty" json:",omitempty"`
+	NodeSortPolicy    NodeSortingPolicy         `yaml:",omitempty" json:",omitempty"`
+	StateDumpFilePath string                    `yaml:",omitempty" json:",omitempty"`
 }
 
 type PartitionPreemptionConfig struct {

--- a/pkg/common/configs/config_test.go
+++ b/pkg/common/configs/config_test.go
@@ -642,6 +642,40 @@ partitions:
 	}
 }
 
+func TestPartitionStateDumpFilePathParameter(t *testing.T) {
+	data := `
+partitions:
+  - name: default
+    queues:
+      - name: root
+    statedumpfilepath: "yunikorn-state.txt"
+  - name: "partition-0"
+    queues:
+      - name: root
+`
+	// validate the config and check after the update
+	conf, err := CreateConfig(data)
+	assert.NilError(t, err, "should expect no error")
+	stateDumpFilePath := "yunikorn-state.txt"
+	assert.Equal(t, conf.Partitions[0].StateDumpFilePath, stateDumpFilePath)
+	assert.Equal(t, conf.Partitions[1].StateDumpFilePath, "")
+}
+
+func TestPartitionStateDumpFilePathParameterFail(t *testing.T) {
+	data := `
+partitions:
+  - name: default
+    queues:
+      - name: root
+    statedumpfilepath: "/yunikorn-state.txt"
+`
+	// validate the config and check after the update
+	conf, err := CreateConfig(data)
+	if err == nil {
+		t.Errorf("stateDumpFilePath field should have failed due to insufficient permissions: %v", conf)
+	}
+}
+
 func TestParseRule(t *testing.T) {
 	data := `
 partitions:

--- a/pkg/scheduler/partition.go
+++ b/pkg/scheduler/partition.go
@@ -61,6 +61,7 @@ type PartitionContext struct {
 	userGroupCache         *security.UserGroupCache        // user cache per partition
 	totalPartitionResource *resources.Resource             // Total node resources
 	allocations            int                             // Number of allocations on the partition
+	stateDumpFilePath      string                          // Path of output file for state dumps
 
 	// The partition write lock must not be held while manipulating an application.
 	// Scheduling is running continuously as a lock free background task. Scheduling an application
@@ -132,6 +133,7 @@ func (pc *PartitionContext) initialPartitionFromConfig(conf configs.PartitionCon
 	// TODO get the resolver from the config
 	pc.userGroupCache = security.GetUserGroupCache("")
 	pc.updateNodeSortingPolicy(conf)
+	pc.updateStateDumpFilePath(conf)
 	return nil
 }
 
@@ -148,6 +150,15 @@ func (pc *PartitionContext) updateNodeSortingPolicy(conf configs.PartitionConfig
 			zap.String("policyName", configuredPolicy.String()))
 	}
 	pc.nodes.SetNodeSortingPolicy(objects.NewNodeSortingPolicy(conf.NodeSortPolicy.Type, conf.NodeSortPolicy.ResourceWeights))
+}
+
+// NOTE: this is a lock free call. It should only be called holding the PartitionContext lock.
+func (pc *PartitionContext) updateStateDumpFilePath(conf configs.PartitionConfig) {
+	stateDumpFilePath := pc.GetStateDumpFilePath()
+	if stateDumpFilePath != conf.StateDumpFilePath {
+		log.Logger().Info(fmt.Sprintf("State dump file path was %s, changing to %s", stateDumpFilePath, conf.StateDumpFilePath))
+		pc.stateDumpFilePath = conf.StateDumpFilePath
+	}
 }
 
 func (pc *PartitionContext) updatePartitionDetails(conf configs.PartitionConfig) error {
@@ -173,6 +184,7 @@ func (pc *PartitionContext) updatePartitionDetails(conf configs.PartitionConfig)
 		pc.placementManager = placement.NewPlacementManager(*pc.rules, pc.GetQueue)
 	}
 	pc.updateNodeSortingPolicy(conf)
+	pc.updateStateDumpFilePath(conf)
 	// start at the root: there is only one queue
 	queueConf := conf.Queues[0]
 	root := pc.root
@@ -529,6 +541,12 @@ func (pc *PartitionContext) createQueue(name string, user security.UserGroup) (*
 		}
 	}
 	return queue, nil
+}
+
+// Get the state dump output file path from the partition.
+// NOTE: this is a lock free call. It should only be called holding the PartitionContext lock.
+func (pc *PartitionContext) GetStateDumpFilePath() string {
+	return pc.stateDumpFilePath
 }
 
 // Get a node from the partition by nodeID.

--- a/pkg/scheduler/partition_test.go
+++ b/pkg/scheduler/partition_test.go
@@ -920,6 +920,23 @@ func TestGetQueue(t *testing.T) {
 	assert.Equal(t, queue, parent, "partition returned nil for existing queue name request")
 }
 
+func TestGetStateDumpFilePath(t *testing.T) {
+	// get the partition
+	partition, err := newBasePartition()
+	partition.RLock()
+	defer partition.RUnlock()
+
+	assert.NilError(t, err, "test partition create failed with error")
+	stateDumpFilePath := partition.GetStateDumpFilePath()
+	assert.Equal(t, stateDumpFilePath, "")
+
+	partition, err = newStateDumpFilePartition()
+	assert.NilError(t, err, "test partition create failed with error")
+	fileName := "yunikorn-state.txt"
+	stateDumpFilePath = partition.GetStateDumpFilePath()
+	assert.Equal(t, stateDumpFilePath, fileName)
+}
+
 func TestTryAllocate(t *testing.T) {
 	partition := createQueuesNodes(t)
 	if partition == nil {
@@ -2047,4 +2064,39 @@ func TestUpdateNodeSortingPolicy(t *testing.T) {
 	})
 
 	assert.Equal(t, partition.nodes.GetNodeSortingPolicy().PolicyType(), policies.BinPackingPolicy)
+}
+
+func TestUpdateStateDumpFilePath(t *testing.T) {
+	partition, err := newBasePartition()
+	partition.RLock()
+	defer partition.RUnlock()
+	assert.NilError(t, err, "partition create failed")
+
+	assert.Equal(t, partition.GetStateDumpFilePath(), "")
+	stateDumpFilePath := "yunikorn-state.txt"
+
+	partition.updateStateDumpFilePath(configs.PartitionConfig{
+		Name: "test",
+		Queues: []configs.QueueConfig{
+			{
+				Name:      "root",
+				Parent:    true,
+				SubmitACL: "*",
+				Queues: []configs.QueueConfig{
+					{
+						Name:   "default",
+						Parent: false,
+						Queues: nil,
+					},
+				},
+			},
+		},
+		PlacementRules:    nil,
+		Limits:            nil,
+		Preemption:        configs.PartitionPreemptionConfig{},
+		NodeSortPolicy:    configs.NodeSortingPolicy{},
+		StateDumpFilePath: stateDumpFilePath,
+	})
+
+	assert.Equal(t, partition.GetStateDumpFilePath(), stateDumpFilePath)
 }

--- a/pkg/scheduler/utilities_test.go
+++ b/pkg/scheduler/utilities_test.go
@@ -161,6 +161,33 @@ func newPlacementPartition() (*PartitionContext, error) {
 	return newPartitionContext(conf, rmID, nil)
 }
 
+func newStateDumpFilePartition() (*PartitionContext, error) {
+	conf := configs.PartitionConfig{
+		Name: "test",
+		Queues: []configs.QueueConfig{
+			{
+				Name:      "root",
+				Parent:    true,
+				SubmitACL: "*",
+				Queues: []configs.QueueConfig{
+					{
+						Name:   "default",
+						Parent: false,
+						Queues: nil,
+					},
+				},
+			},
+		},
+		PlacementRules:    nil,
+		Limits:            nil,
+		Preemption:        configs.PartitionPreemptionConfig{},
+		NodeSortPolicy:    configs.NodeSortingPolicy{},
+		StateDumpFilePath: "yunikorn-state.txt",
+	}
+
+	return newPartitionContext(conf, rmID, nil)
+}
+
 func newApplication(appID, partition, queueName string) *objects.Application {
 	siApp := &si.AddApplicationRequest{
 		ApplicationID: appID,

--- a/pkg/webservice/handlers_test.go
+++ b/pkg/webservice/handlers_test.go
@@ -90,9 +90,22 @@ partitions:
     queues:
       - name: root
 `
+
 const configDefault = `
 partitions:
   - name: default
+    queues:
+      - name: root
+        submitacl: "*"
+        queues:
+          - name: default
+          - name: noapps
+`
+
+const configStateDumpFilePath = `
+partitions:
+  - name: default
+    statedumpfilepath: "tmp/non-default-yunikorn-state.txt"
     queues:
       - name: root
         submitacl: "*"
@@ -1326,8 +1339,9 @@ func TestGetNodesUtilization(t *testing.T) {
 	assert.Equal(t, len(nodesDao), 0)
 }
 
-func TestGetFullStateDump(t *testing.T) {
-	schedulerContext = prepareSchedulerContext(t)
+func TestGetFullStateDumpDefaultPath(t *testing.T) {
+	schedulerContext = prepareSchedulerContext(t, false)
+	defer deleteStateDumpFile(t, schedulerContext)
 
 	partitionContext := schedulerContext.GetPartitionMapClone()
 	context := partitionContext[normalizedPartitionName]
@@ -1342,19 +1356,54 @@ func TestGetFullStateDump(t *testing.T) {
 	resp := &MockResponseWriter{}
 
 	getFullStateDump(resp, req)
-	receivedBytes := resp.outputBytes
 	statusCode := resp.statusCode
-	assert.Assert(t, len(receivedBytes) > 0, "json response is empty")
+	fi, err := os.Stat(defaultStateDumpFilePath)
+	assert.NilError(t, err)
+	assert.Assert(t, fi.Size() > 0, "json response is empty")
 	assert.Check(t, statusCode != http.StatusInternalServerError, "response status code")
 	var aggregated AggregatedStateInfo
+	receivedBytes, err := ioutil.ReadFile(defaultStateDumpFilePath)
+	assert.NilError(t, err)
+	err = json.Unmarshal(receivedBytes, &aggregated)
+	assert.NilError(t, err)
+	verifyStateDumpJSON(t, &aggregated)
+}
+
+func TestGetFullStateDumpNonDefaultPath(t *testing.T) {
+	stateDumpFilePath := "tmp/non-default-yunikorn-state.txt"
+	defer deleteStateDumpDir(t)
+	schedulerContext = prepareSchedulerContext(t, true)
+	defer deleteStateDumpFile(t, schedulerContext)
+
+	partitionContext := schedulerContext.GetPartitionMapClone()
+	context := partitionContext[normalizedPartitionName]
+	app := newApplication("appID", normalizedPartitionName, "root.default", rmID)
+	err := context.AddApplication(app)
+	assert.NilError(t, err, "failed to add Application to partition")
+
+	imHistory = history.NewInternalMetricsHistory(5)
+	req, err2 := http.NewRequest("GET", "/ws/v1/getfullstatedump", strings.NewReader(""))
+	assert.NilError(t, err2)
+	req = mux.SetURLVars(req, make(map[string]string))
+	resp := &MockResponseWriter{}
+
+	getFullStateDump(resp, req)
+	statusCode := resp.statusCode
+	fi, err := os.Stat(stateDumpFilePath)
+	assert.NilError(t, err)
+	assert.Assert(t, fi.Size() > 0, "json response is empty")
+	assert.Check(t, statusCode != http.StatusInternalServerError, "response status code")
+	var aggregated AggregatedStateInfo
+	receivedBytes, err := ioutil.ReadFile(stateDumpFilePath)
+	assert.NilError(t, err)
 	err = json.Unmarshal(receivedBytes, &aggregated)
 	assert.NilError(t, err)
 	verifyStateDumpJSON(t, &aggregated)
 }
 
 func TestEnableDisablePeriodicStateDump(t *testing.T) {
-	schedulerContext = prepareSchedulerContext(t)
-	defer deleteStateDumpFile(t)
+	schedulerContext = prepareSchedulerContext(t, false)
+	defer deleteStateDumpFile(t, schedulerContext)
 	defer terminateGoroutine()
 
 	imHistory = history.NewInternalMetricsHistory(5)
@@ -1373,7 +1422,7 @@ func TestEnableDisablePeriodicStateDump(t *testing.T) {
 	assert.Equal(t, statusCode, 0, "response status code")
 
 	waitForStateDumpFile(t)
-	fileContents, err2 := ioutil.ReadFile(stateDumpFilePath)
+	fileContents, err2 := ioutil.ReadFile(defaultStateDumpFilePath)
 	assert.NilError(t, err2)
 	var aggregated AggregatedStateInfo
 	err3 := json.Unmarshal(fileContents, &aggregated)
@@ -1394,7 +1443,7 @@ func TestEnableDisablePeriodicStateDump(t *testing.T) {
 }
 
 func TestTryEnableStateDumpTwice(t *testing.T) {
-	defer deleteStateDumpFile(t)
+	defer deleteStateDumpFile(t, schedulerContext)
 	defer terminateGoroutine()
 
 	req, err := http.NewRequest("PUT", "/ws/v1/periodicstatedump", strings.NewReader(""))
@@ -1453,8 +1502,12 @@ func TestIllegalStateDumpRequests(t *testing.T) {
 	assert.Equal(t, statusCode, http.StatusBadRequest, "response status code")
 }
 
-func prepareSchedulerContext(t *testing.T) *scheduler.ClusterContext {
-	configs.MockSchedulerConfigByData([]byte(configDefault))
+func prepareSchedulerContext(t *testing.T, stateDumpConf bool) *scheduler.ClusterContext {
+	if !stateDumpConf {
+		configs.MockSchedulerConfigByData([]byte(configDefault))
+	} else {
+		configs.MockSchedulerConfigByData([]byte(configStateDumpFilePath))
+	}
 	var err error
 	schedulerContext, err = scheduler.NewClusterContext(rmID, policyGroup)
 	assert.NilError(t, err, "Error when load clusterInfo from config")
@@ -1466,7 +1519,7 @@ func prepareSchedulerContext(t *testing.T) *scheduler.ClusterContext {
 func waitForStateDumpFile(t *testing.T) {
 	var attempts int
 	for {
-		info, err := os.Stat(stateDumpFilePath)
+		info, err := os.Stat(defaultStateDumpFilePath)
 		// tolerate only "file not found" errors
 		if err != nil && !os.IsNotExist(err) {
 			t.Fatal(err)
@@ -1484,8 +1537,15 @@ func waitForStateDumpFile(t *testing.T) {
 	}
 }
 
-func deleteStateDumpFile(t *testing.T) {
+func deleteStateDumpFile(t *testing.T, cc *scheduler.ClusterContext) {
+	stateDumpFilePath := getStateDumpFilePath(cc)
 	if err := os.Remove(stateDumpFilePath); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func deleteStateDumpDir(t *testing.T) {
+	if err := os.Remove("tmp"); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
### What is this PR for?
Location of the state dump file should be configurable instead of hardcoded. PR also provides a default retention policy to ensure the file does not grow unbounded.   

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos

### What is the Jira issue?
* https://issues.apache.org/jira/browse/YUNIKORN-949

### How should this be tested?
* Modified tests in handlers_test.go and manual testing

### Screenshots (if appropriate)
<img width="311" alt="Screen Shot 2022-01-23 at 3 12 16 PM" src="https://user-images.githubusercontent.com/15059525/150702056-4939f519-67f0-428a-a02f-1603d94a0206.png">
<img width="401" alt="Screen Shot 2022-01-23 at 3 12 31 PM" src="https://user-images.githubusercontent.com/15059525/150702062-f3092fb9-8ef6-4928-8076-d16293e35ddb.png">
<img width="1084" alt="Screen Shot 2022-01-23 at 3 13 13 PM" src="https://user-images.githubusercontent.com/15059525/150702064-20073ec9-9a06-4a8f-9fa8-dbe98c21ec05.png">

### Questions:
