### PR TITLE
[YUNIKORN-1065] panic on node update

### DIFF
--- a/pkg/metrics/event.go
+++ b/pkg/metrics/event.go
@@ -86,6 +86,16 @@ func initEventMetrics() CoreEventMetrics {
 	return metrics
 }
 
+func (em *eventMetrics) Reset() {
+	em.totalEventsCollected.Set(0)
+	em.totalEventsCreated.Set(0)
+	em.totalEventsChanneled.Set(0)
+	em.totalEventsNotChanneled.Set(0)
+	em.totalEventsStored.Set(0)
+	em.totalEventsNotStored.Set(0)
+	em.totalEventsProcessed.Set(0)
+}
+
 func (em *eventMetrics) IncEventsCreated() {
 	em.totalEventsCreated.Inc()
 }

--- a/pkg/metrics/queue.go
+++ b/pkg/metrics/queue.go
@@ -78,6 +78,11 @@ func substituteQueueName(queueName string) string {
 	return strings.Replace(str, "-", "_", -1)
 }
 
+func (m *QueueMetrics) Reset() {
+	m.appMetrics.Reset()
+	m.ResourceMetrics.Reset()
+}
+
 func (m *QueueMetrics) IncQueueApplicationsRunning() {
 	m.appMetrics.With(prometheus.Labels{"state": "running"}).Inc()
 }

--- a/pkg/metrics/scheduler.go
+++ b/pkg/metrics/scheduler.go
@@ -102,7 +102,7 @@ func InitSchedulerMetrics() *SchedulerMetrics {
 			Subsystem: SchedulerSubsystem,
 			Name:      "scheduling_latency_milliseconds",
 			Help:      "Latency of the main scheduling routine, in milliseconds.",
-			Buckets:   prometheus.ExponentialBuckets(0.0001, 10, 6), //start from 0.1ms
+			Buckets:   prometheus.ExponentialBuckets(0.0001, 10, 6), // start from 0.1ms
 		},
 	)
 	s.sortingLatency = prometheus.NewHistogramVec(
@@ -111,7 +111,7 @@ func InitSchedulerMetrics() *SchedulerMetrics {
 			Subsystem: SchedulerSubsystem,
 			Name:      "node_sorting_latency_milliseconds",
 			Help:      "Latency of all nodes sorting, in milliseconds.",
-			Buckets:   prometheus.ExponentialBuckets(0.0001, 10, 6), //start from 0.1ms
+			Buckets:   prometheus.ExponentialBuckets(0.0001, 10, 6), // start from 0.1ms
 		}, []string{"level"})
 
 	s.tryNodeLatency = prometheus.NewHistogram(
@@ -142,7 +142,12 @@ func InitSchedulerMetrics() *SchedulerMetrics {
 	return s
 }
 
-func Reset() {}
+func (m *SchedulerMetrics) Reset() {
+	m.node.Reset()
+	m.application.Reset()
+	m.applicationSubmission.Reset()
+	m.containerAllocation.Reset()
+}
 
 func SinceInSeconds(start time.Time) float64 {
 	return time.Since(start).Seconds()

--- a/pkg/scheduler/context_test.go
+++ b/pkg/scheduler/context_test.go
@@ -24,9 +24,12 @@ import (
 	"gotest.tools/assert"
 
 	"github.com/apache/incubator-yunikorn-core/pkg/common/configs"
+	"github.com/apache/incubator-yunikorn-core/pkg/common/resources"
 	"github.com/apache/incubator-yunikorn-core/pkg/rmproxy/rmevent"
 	"github.com/apache/incubator-yunikorn-scheduler-interface/lib/go/si"
 )
+
+const pName = "default"
 
 type mockEventHandler struct {
 	eventHandled  bool
@@ -56,14 +59,14 @@ func (m *mockEventHandler) HandleEvent(ev interface{}) {
 	}
 }
 
-func TestAddUnlimitedNode(t *testing.T) {
+func createTestContext(t *testing.T, partitionName string) *ClusterContext {
 	handler := newMockEventHandler()
 	context := &ClusterContext{
 		partitions:     map[string]*PartitionContext{},
 		rmEventHandler: handler,
 	}
 	conf := configs.PartitionConfig{
-		Name: "default",
+		Name: partitionName,
 		Queues: []configs.QueueConfig{
 			{
 				Name:      "root",
@@ -74,8 +77,14 @@ func TestAddUnlimitedNode(t *testing.T) {
 		},
 	}
 	partition, err := newPartitionContext(conf, "test", context)
-	context.partitions[partition.Name] = partition
 	assert.NilError(t, err, "partition create should not have failed with error")
+	context.partitions[partition.Name] = partition
+	return context
+}
+
+func TestAddUnlimitedNode(t *testing.T) {
+	context := createTestContext(t, "default")
+
 	unlimitedNode := &si.NodeInfo{
 		NodeID:     "unlimited",
 		Attributes: map[string]string{"yunikorn.apache.org/nodeType": "unlimited", "si/node-partition": "default"},
@@ -87,6 +96,9 @@ func TestAddUnlimitedNode(t *testing.T) {
 	request := &si.NodeRequest{
 		Nodes: newNodes,
 	}
+
+	handler, ok := context.rmEventHandler.(*mockEventHandler)
+	assert.Assert(t, ok, "incorrect handler set in context")
 
 	// 1. add the first unlimited node, but keep reservation enabled
 	context.processNodes(request)
@@ -131,6 +143,7 @@ func TestAddUnlimitedNode(t *testing.T) {
 	newNodes2 = append(newNodes2, unlimitedNode, regularNode)
 	request2.Nodes = newNodes2
 	handler.reset()
+	partition := context.GetPartition(pName)
 	_, _ = partition.removeNode(unlimitedNode.NodeID)
 	context.processNodes(request2)
 	assert.Assert(t, handler.eventHandled, "Event should have been handled")
@@ -145,4 +158,105 @@ func TestAddUnlimitedNode(t *testing.T) {
 	assert.Assert(t, len(handler.acceptedNodes) == 0, "There should be no accepted node")
 	assert.Assert(t, len(handler.rejectedNodes) == 1, "The node should be rejected")
 	assert.Equal(t, handler.rejectedNodes[0].NodeID, unlimitedNode.NodeID, "The rejected node is not the unlimited one")
+}
+
+func TestContext_UpdateNode(t *testing.T) {
+	context := createTestContext(t, pName)
+	n := &si.NodeInfo{
+		NodeID:              "test-1",
+		Action:              si.NodeInfo_UNKNOWN_ACTION_FROM_RM,
+		SchedulableResource: &si.Resource{Resources: map[string]*si.Quantity{"first": {Value: 10}}},
+	}
+	full := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 10})
+	half := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 5})
+	partition := context.GetPartition(pName)
+	// no partition set
+	context.updateNode(n)
+	assert.Equal(t, 0, len(partition.GetNodes()), "unexpected node found on partition (no partition set)")
+	n.Attributes = map[string]string{"si/node-partition": "unknown"}
+	context.updateNode(n)
+	assert.Equal(t, 0, len(partition.GetNodes()), "unexpected node found on partition (unknown partition set)")
+	n.Attributes = map[string]string{"si/node-partition": pName}
+	context.updateNode(n)
+	assert.Equal(t, 0, len(partition.GetNodes()), "unexpected node found on partition (correct partition set)")
+	// add the node to the context
+	err := context.addNode(n, 1)
+	assert.NilError(t, err, "unexpected error returned from addNode")
+	assert.Equal(t, 1, len(partition.GetNodes()), "expected node not found on partition")
+	assert.Assert(t, resources.Equals(full, partition.GetTotalPartitionResource()), "partition resource should be updated")
+	// try to update: fail due to unknown action
+	n.SchedulableResource = &si.Resource{Resources: map[string]*si.Quantity{"first": {Value: 5}}}
+	n.OccupiedResource = &si.Resource{Resources: map[string]*si.Quantity{"first": {Value: 5}}}
+	context.updateNode(n)
+	node := partition.GetNode("test-1")
+	assert.Assert(t, resources.Equals(full, node.GetAvailableResource()), "node available resource should not be updated")
+	n.Action = si.NodeInfo_UPDATE
+	context.updateNode(n)
+	assert.Assert(t, resources.Equals(half, partition.GetTotalPartitionResource()), "partition resource should be updated")
+	assert.Assert(t, resources.IsZero(node.GetAvailableResource()), "node available should have been updated to zero")
+	assert.Assert(t, resources.Equals(half, node.GetOccupiedResource()), "node occupied should have been updated")
+
+	// other actions
+	n = &si.NodeInfo{
+		NodeID:     "test-1",
+		Action:     si.NodeInfo_DRAIN_NODE,
+		Attributes: map[string]string{"si/node-partition": pName},
+	}
+	context.updateNode(n)
+	assert.Assert(t, !node.IsSchedulable(), "node should be marked as unschedulable")
+	n.Action = si.NodeInfo_DRAIN_TO_SCHEDULABLE
+	context.updateNode(n)
+	assert.Assert(t, node.IsSchedulable(), "node should be marked as schedulable")
+	n.Action = si.NodeInfo_DECOMISSION
+	context.updateNode(n)
+	assert.Equal(t, 0, len(partition.GetNodes()), "unexpected node found on partition node should have been removed")
+	assert.Assert(t, resources.IsZero(partition.GetTotalPartitionResource()), "partition resource should be zero")
+	assert.Assert(t, !node.IsSchedulable(), "node should be marked as unschedulable")
+}
+
+func TestContext_AddNode(t *testing.T) {
+	context := createTestContext(t, pName)
+
+	n := &si.NodeInfo{
+		NodeID:              "test-1",
+		Action:              si.NodeInfo_CREATE,
+		Attributes:          map[string]string{"si/node-partition": "unknown"},
+		SchedulableResource: &si.Resource{Resources: map[string]*si.Quantity{"first": {Value: 10}}},
+	}
+	err := context.addNode(n, 1)
+	if err == nil {
+		t.Fatalf("unknown node partition should have failed the node add")
+	}
+	n.Attributes = map[string]string{"si/node-partition": pName}
+	err = context.addNode(n, 1)
+	assert.NilError(t, err, "unexpected error returned adding node")
+	partition := context.GetPartition(pName)
+	assert.Equal(t, 1, len(partition.GetNodes()), "expected node not found on partition")
+	// add same node again should show an error
+	err = context.addNode(n, 1)
+	if err == nil {
+		t.Fatalf("existing node addition should have failed")
+	}
+}
+
+func TestContext_ProcessNode(t *testing.T) {
+	// make sure we're nil safe IDE will complain about the non nil check
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatal("panic on nil node info in processNodes test")
+		}
+	}()
+	context := createTestContext(t, pName)
+
+	request := &si.NodeRequest{
+		Nodes: []*si.NodeInfo{
+			nil,
+			{NodeID: "test-1", Action: si.NodeInfo_CREATE, Attributes: map[string]string{"si/node-partition": pName}},
+		},
+	}
+	context.processNodes(request)
+	node := context.GetNode("test-1", pName)
+	if node == nil {
+		t.Fatalf("expected node to be added skipping nil node in list")
+	}
 }

--- a/pkg/scheduler/health_checker_test.go
+++ b/pkg/scheduler/health_checker_test.go
@@ -111,6 +111,7 @@ func TestGetSchedulerHealthStatusContext(t *testing.T) {
 
 func TestGetSchedulerHealthStatusMetrics(t *testing.T) {
 	configs.MockSchedulerConfigByData([]byte(configDefault))
+	metrics.Reset()
 	schedulerMetrics := metrics.GetSchedulerMetrics()
 	schedulerContext, err := NewClusterContext("rmID", "policyGroup")
 	assert.NilError(t, err, "Error when load schedulerContext from config")


### PR DESCRIPTION
### What is this PR for?
If a node is not found during the update logging causes a panic as it
refers to the wrong object. Fixed another possible panic in node
processing in the context. Unit tests added to cover the panic cases.

Fixed layout and formatting issues in error messages and comments

### What type of PR is it?
* [X] - Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1065

### How should this be tested?
Unit tests cover all problem cases.