### PR TITLE
[YUNIKORN-1092] reservation matching on full names only

### DIFF
--- a/pkg/scheduler/objects/application.go
+++ b/pkg/scheduler/objects/application.go
@@ -587,7 +587,7 @@ func (sa *Application) hasReserved() bool {
 	return len(sa.reservations) > 0
 }
 
-// Return if the application has the node reserved.
+// IsReservedOnNode returns true if and only if the node has been reserved by the application
 // An empty nodeID is never reserved.
 func (sa *Application) IsReservedOnNode(nodeID string) bool {
 	if nodeID == "" {
@@ -595,8 +595,10 @@ func (sa *Application) IsReservedOnNode(nodeID string) bool {
 	}
 	sa.RLock()
 	defer sa.RUnlock()
+	// make sure matches only for the whole nodeID
+	separator := nodeID + "|"
 	for key := range sa.reservations {
-		if strings.HasPrefix(key, nodeID) {
+		if strings.HasPrefix(key, separator) {
 			return true
 		}
 	}

--- a/pkg/scheduler/objects/application_test.go
+++ b/pkg/scheduler/objects/application_test.go
@@ -140,6 +140,12 @@ func TestAppReservation(t *testing.T) {
 		t.Errorf("app should have reservations for node %s", nodeID1)
 	}
 
+	// node name similarity check: chop of the last char to make sure we check the full name
+	similar := nodeID1[:len(nodeID1)-1]
+	if app.hasReserved() && app.IsReservedOnNode(similar) {
+		t.Errorf("similar app should not have reservations for node %s", similar)
+	}
+
 	// reserve the same reservation
 	err = app.Reserve(node, ask)
 	if err == nil {

--- a/pkg/scheduler/objects/node.go
+++ b/pkg/scheduler/objects/node.go
@@ -469,7 +469,7 @@ func (sn *Node) IsUnlimited() bool {
 	return sn.unlimited
 }
 
-// Return true if and only if the node has been reserved by the application
+// isReservedForApp returns true if and only if the node has been reserved by the application
 // NOTE: a return value of false does not mean the node is not reserved by a different app
 func (sn *Node) isReservedForApp(key string) bool {
 	if key == "" {
@@ -480,8 +480,10 @@ func (sn *Node) isReservedForApp(key string) bool {
 	if strings.Contains(key, "|") {
 		return sn.reservations[key] != nil
 	}
+	// make sure matches only for the whole appID
+	separator := key + "|"
 	for resKey := range sn.reservations {
-		if strings.HasPrefix(resKey, key) {
+		if strings.HasPrefix(resKey, separator) {
 			return true
 		}
 	}

--- a/pkg/scheduler/objects/node_test.go
+++ b/pkg/scheduler/objects/node_test.go
@@ -383,6 +383,11 @@ func TestIsReservedForApp(t *testing.T) {
 	if !node.isReservedForApp("app-1|alloc-1") {
 		t.Error("node was reserved for this app/alloc but check did not passed ")
 	}
+	// app name similarity check: chop of the last char to make sure we check the full name
+	similar := appID1[:len(appID1)-1]
+	if node.isReservedForApp(similar) {
+		t.Errorf("similar app should not have reservations on node %s", similar)
+	}
 }
 
 func TestAttributes(t *testing.T) {


### PR DESCRIPTION
### What is this PR for?
Reservation matching should match the name of the app or node up until
the separator. Similar names would otherwise cause false positives while
being checked: i.e. node-1 and node-10, node-1 matches node-10's
reservations.

### What type of PR is it?
* [X ] - Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1092

### How should this be tested?
unit tests are added to test the change