### PR TITLE
[YUNIKORN-1106] Reduce idle CPU usage

### DIFF
--- a/pkg/scheduler/context.go
+++ b/pkg/scheduler/context.go
@@ -107,11 +107,13 @@ func (cc *ClusterContext) setEventHandler(rmHandler handler.EventHandler) {
 	cc.rmEventHandler = rmHandler
 }
 
-// The main scheduling routine.
+// schedule is the main scheduling routine.
 // Process each partition in the scheduler, walk over each queue and app to check if anything can be scheduled.
-// This can be forked into a go routine per partition if needed to increase parallel allocations
-func (cc *ClusterContext) schedule() {
+// This can be forked into a go routine per partition if needed to increase parallel allocations.
+// Returns true if an allocation was able to be scheduled.
+func (cc *ClusterContext) schedule() bool {
 	// schedule each partition defined in the cluster
+	activity := false
 	for _, psc := range cc.GetPartitionMapClone() {
 		// if there are no resources in the partition just skip
 		if psc.root.GetMaxResource() == nil {
@@ -140,8 +142,10 @@ func (cc *ClusterContext) schedule() {
 			} else {
 				cc.notifyRMNewAllocation(psc.RmID, alloc)
 			}
+			activity = true
 		}
 	}
+	return activity
 }
 
 func (cc *ClusterContext) processRMRegistrationEvent(event *rmevent.RMRegistrationEvent) {


### PR DESCRIPTION
### What is this PR for?
Adds a 10ms sleep when the scheduler loop makes no progress. This reduces CPU usage considerably, with negligible impact on performance.

The sleep is conditional on no activity happening within the main scheduler loop. Any pod being scheduled, or any event received from the shim will set a flag indicating that the next sleep should be skipped. This minimizes the impact overall, but keeps the scheduler from consuming a core (or more) when not needed.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1106

### How should this be tested?
No behavioral changes here, just performance.

Ran scenario locally with batch job of 100 completions, 20 parallelism, each container runs 'sleep 5'. 
- Existing code: 2m24s job duration, baseline CPU usage varied between 114-139%.
- 100ms sleep: 2m26s duration, baseline CPU usage ~ 0.4%
- 10ms sleep: 2m19s duration (improvement!), baseline CPU usage ~ 2.3%

Given that 10ms sleep reduced CPU usage by almost 50x and actually increased performance, this seems like a good compromise. 

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
