### PR TITLE
[YUNIKORN-1109] Fix data race in core event handling

### DIFF
--- a/pkg/scheduler/context.go
+++ b/pkg/scheduler/context.go
@@ -907,8 +907,12 @@ func (cc *ClusterContext) SetRMInfos(rmID string, rmBuildInformation map[string]
 	if cc.rmInfos == nil {
 		cc.rmInfos = make(map[string]*RMInformation)
 	}
-	cc.rmInfos[rmID] = &RMInformation{
-		RMBuildInformation: rmBuildInformation,
+	buildInfo := make(map[string]string)
+	for k, v := range rmBuildInformation {
+		buildInfo[k] = v
 	}
-	cc.rmInfos[rmID].RMBuildInformation["rmId"] = rmID
+	buildInfo["rmId"] = rmID
+	cc.rmInfos[rmID] = &RMInformation{
+		RMBuildInformation: buildInfo,
+	}
 }

--- a/pkg/scheduler/context_test.go
+++ b/pkg/scheduler/context_test.go
@@ -272,11 +272,13 @@ func TestContext_AddRMBuildInformation(t *testing.T) {
 
 	context.SetRMInfos(rmID1, buildInfoMap1)
 	assert.Equal(t, 1, len(context.rmInfos))
+	buildInfoMap1["rmId"] = rmID1
 	assert.DeepEqual(t, context.rmInfos[rmID1].RMBuildInformation, buildInfoMap1)
 	assert.Equal(t, context.rmInfos[rmID1].RMBuildInformation["rmId"], rmID1)
 
 	context.SetRMInfos(rmID2, buildInfoMap2)
 	assert.Equal(t, 2, len(context.rmInfos))
+	buildInfoMap2["rmId"] = rmID2
 	assert.DeepEqual(t, context.rmInfos[rmID2].RMBuildInformation, buildInfoMap2)
 	assert.Equal(t, context.rmInfos[rmID2].RMBuildInformation["rmId"], rmID2)
 
@@ -288,6 +290,7 @@ func TestContext_AddRMBuildInformation(t *testing.T) {
 	buildInfoMap3["buildVersion"] = "1.0.0"
 	context.SetRMInfos(rmID2, buildInfoMap3)
 	assert.Equal(t, 2, len(context.rmInfos))
+	buildInfoMap3["rmId"] = rmID2
 	assert.DeepEqual(t, context.rmInfos[rmID2].RMBuildInformation, buildInfoMap3)
 	assert.Equal(t, context.rmInfos[rmID2].RMBuildInformation["buildVersion"], buildInfoMap3["buildVersion"])
 }


### PR DESCRIPTION
### What is this PR for?
Fixes a data race when registering an RM due to the input data of an event being modified.

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1109

### How should this be tested?
Unit tests updated to reflect that the event data is now copied instead of referenced.

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
