### PR TITLE
[YUNIKORN-1124] Avoid passing empty nodeAttributes in UpdateNode request

### DIFF
--- a/pkg/rmproxy/rmproxy.go
+++ b/pkg/rmproxy/rmproxy.go
@@ -365,6 +365,9 @@ func (rmp *RMProxy) UpdateNode(request *si.NodeRequest) error {
 	go func() {
 		if len(request.Nodes) > 0 {
 			for _, node := range request.Nodes {
+				if len(node.GetAttributes()) == 0 {
+					node.Attributes = map[string]string{}
+				}
 				partition := node.Attributes[siCommon.NodePartition]
 				node.Attributes[siCommon.NodePartition] = common.GetNormalizedPartitionName(partition, request.RmID)
 			}

--- a/pkg/scheduler/tests/mockscheduler_test.go
+++ b/pkg/scheduler/tests/mockscheduler_test.go
@@ -95,9 +95,8 @@ func (m *mockScheduler) removeNode(nodeID string) error {
 	return m.proxy.UpdateNode(&si.NodeRequest{
 		Nodes: []*si.NodeInfo{
 			{
-				NodeID:     nodeID,
-				Action:     si.NodeInfo_DECOMISSION,
-				Attributes: map[string]string{},
+				NodeID: nodeID,
+				Action: si.NodeInfo_DECOMISSION,
 			},
 		},
 		RmID: m.rmID,

--- a/pkg/scheduler/tests/operation_test.go
+++ b/pkg/scheduler/tests/operation_test.go
@@ -294,9 +294,8 @@ partitions:
 	err = ms.proxy.UpdateNode(&si.NodeRequest{
 		Nodes: []*si.NodeInfo{
 			{
-				NodeID:     "node-1:1234",
-				Action:     si.NodeInfo_DECOMISSION,
-				Attributes: map[string]string{},
+				NodeID: "node-1:1234",
+				Action: si.NodeInfo_DECOMISSION,
 			},
 		},
 		RmID: "rm:123",

--- a/pkg/scheduler/tests/smoke_test.go
+++ b/pkg/scheduler/tests/smoke_test.go
@@ -991,9 +991,8 @@ partitions:
 	err = ms.proxy.UpdateNode(&si.NodeRequest{
 		Nodes: []*si.NodeInfo{
 			{
-				NodeID:     node1ID,
-				Action:     si.NodeInfo_DRAIN_NODE,
-				Attributes: make(map[string]string),
+				NodeID: node1ID,
+				Action: si.NodeInfo_DRAIN_NODE,
 			},
 		},
 		RmID: "rm:123",
@@ -1012,9 +1011,8 @@ partitions:
 	err = ms.proxy.UpdateNode(&si.NodeRequest{
 		Nodes: []*si.NodeInfo{
 			{
-				NodeID:     node1ID,
-				Action:     si.NodeInfo_DRAIN_TO_SCHEDULABLE,
-				Attributes: make(map[string]string),
+				NodeID: node1ID,
+				Action: si.NodeInfo_DRAIN_TO_SCHEDULABLE,
 			},
 		},
 		RmID: "rm:123",
@@ -1033,9 +1031,8 @@ partitions:
 	err = ms.proxy.UpdateNode(&si.NodeRequest{
 		Nodes: []*si.NodeInfo{
 			{
-				NodeID:     node2ID,
-				Action:     si.NodeInfo_DECOMISSION,
-				Attributes: make(map[string]string),
+				NodeID: node2ID,
+				Action: si.NodeInfo_DECOMISSION,
 			},
 		},
 		RmID: "rm:123",


### PR DESCRIPTION
### What is this PR for?

Core initialise nodeAttributes map and set the default partition when shim is not passing nodeAttributes as part of UpdateRequest (for delete, restore & decommissioning actions).

### What type of PR is it?
* [ ] - Improvement

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1124

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
