### PR TITLE
[YUNIKORN-165] Return REST API resource fields as map structures

### DIFF
--- a/pkg/common/resources/resources.go
+++ b/pkg/common/resources/resources.go
@@ -112,11 +112,14 @@ func (r *Resource) String() string {
 	return fmt.Sprintf("%v", r.Resources)
 }
 
-func (r *Resource) DAOString() string {
+func (r *Resource) DAOMap() map[string]int64 {
+	res := make(map[string]int64)
 	if r != nil {
-		return strings.Trim(r.String(), "map")
+		for k, v := range r.Resources {
+			res[k] = int64(v)
+		}
 	}
-	return "[]"
+	return res
 }
 
 // Convert to a protobuf implementation

--- a/pkg/common/resources/resources_test.go
+++ b/pkg/common/resources/resources_test.go
@@ -1572,37 +1572,39 @@ func TestNewResourceFromString(t *testing.T) {
 	}
 }
 
-func TestDAOStringNil(t *testing.T) {
+func TestDAOMapNil(t *testing.T) {
 	// make sure we're nil safe IDE will complain about the non nil check
 	defer func() {
 		if r := recover(); r != nil {
-			t.Fatal("panic on nil resource in daostring test")
+			t.Fatal("panic on nil resource in daomap test")
 		}
 	}()
 	var empty *Resource
-	assert.Equal(t, empty.DAOString(), "[]", "expected empty brackets on nil")
+	assert.DeepEqual(t, empty.DAOMap(), map[string]int64{})
 }
 
-func TestDAOString(t *testing.T) {
+func TestDAOMap(t *testing.T) {
 	tests := map[string]struct {
-		dao string
+		dao map[string]int64
 		res *Resource
 	}{
 		"empty resource": {
-			dao: "[]",
+			dao: map[string]int64{},
 			res: NewResource(),
 		},
 		"single value": {
-			dao: "[first:1]",
+			dao: map[string]int64{"first": 1},
 			res: NewResourceFromMap(map[string]Quantity{"first": 1}),
 		},
 		"two values": {
-			dao: "[first:10 second:-10]",
+			dao: map[string]int64{"first": 10, "second": -10},
 			res: NewResourceFromMap(map[string]Quantity{"first": 10, "second": -10}),
 		},
 	}
 	for name, test := range tests {
-		assert.Equal(t, test.res.DAOString(), test.dao, "unexpected dao string for %s", name)
+		t.Run(name, func(t *testing.T) {
+			assert.DeepEqual(t, test.res.DAOMap(), test.dao)
+		})
 	}
 }
 

--- a/pkg/scheduler/objects/queue.go
+++ b/pkg/scheduler/objects/queue.go
@@ -424,11 +424,11 @@ func (sq *Queue) GetQueueInfos() dao.QueueDAOInfo {
 	queueInfo.QueueName = sq.Name
 	queueInfo.Status = sq.stateMachine.Current()
 	queueInfo.Capacities = dao.QueueCapacity{
-		Capacity:     sq.guaranteedResource.DAOString(),
-		MaxCapacity:  sq.maxResource.DAOString(),
-		UsedCapacity: sq.allocatedResource.DAOString(),
+		Capacity:     sq.guaranteedResource.DAOMap(),
+		MaxCapacity:  sq.maxResource.DAOMap(),
+		UsedCapacity: sq.allocatedResource.DAOMap(),
 		AbsUsedCapacity: resources.CalculateAbsUsedCapacity(
-			sq.maxResource, sq.allocatedResource).DAOString(),
+			sq.maxResource, sq.allocatedResource).DAOMap(),
 	}
 	queueInfo.Properties = make(map[string]string)
 	for k, v := range sq.properties {
@@ -451,14 +451,14 @@ func (sq *Queue) GetPartitionQueueDAOInfo() dao.PartitionQueueDAOInfo {
 
 	queueInfo.QueueName = sq.QueuePath
 	queueInfo.Status = sq.stateMachine.Current()
-	queueInfo.MaxResource = sq.maxResource.DAOString()
-	queueInfo.GuaranteedResource = sq.guaranteedResource.DAOString()
-	queueInfo.AllocatedResource = sq.allocatedResource.DAOString()
+	queueInfo.MaxResource = sq.maxResource.DAOMap()
+	queueInfo.GuaranteedResource = sq.guaranteedResource.DAOMap()
+	queueInfo.AllocatedResource = sq.allocatedResource.DAOMap()
 	queueInfo.IsLeaf = sq.isLeaf
 	queueInfo.IsManaged = sq.isManaged
 	queueInfo.TemplateInfo = sq.template.GetTemplateInfo()
 	queueInfo.AbsUsedCapacity = resources.CalculateAbsUsedCapacity(
-		sq.maxResource, sq.allocatedResource).DAOString()
+		sq.maxResource, sq.allocatedResource).DAOMap()
 	queueInfo.Properties = make(map[string]string)
 	for k, v := range sq.properties {
 		queueInfo.Properties[k] = v

--- a/pkg/scheduler/objects/queue_test.go
+++ b/pkg/scheduler/objects/queue_test.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
-	"strings"
 	"testing"
 	"time"
 
@@ -1294,21 +1293,21 @@ func compareQueueInfoWithDAO(t *testing.T, queue *Queue, dao dao.QueueDAOInfo) {
 	assert.Equal(t, queue.Name, dao.QueueName)
 	assert.Equal(t, len(queue.children), len(dao.ChildQueues))
 	assert.Equal(t, queue.stateMachine.Current(), dao.Status)
-	emptyRes := "[]"
+	emptyRes := map[string]int64{}
 	if queue.allocatedResource == nil {
-		assert.Equal(t, emptyRes, dao.Capacities.UsedCapacity)
+		assert.DeepEqual(t, emptyRes, dao.Capacities.UsedCapacity)
 	} else {
-		assert.Equal(t, strings.Trim(queue.allocatedResource.String(), "map"), dao.Capacities.UsedCapacity)
+		assert.DeepEqual(t, queue.allocatedResource.DAOMap(), dao.Capacities.UsedCapacity)
 	}
 	if queue.maxResource == nil {
-		assert.Equal(t, emptyRes, dao.Capacities.MaxCapacity)
+		assert.DeepEqual(t, emptyRes, dao.Capacities.MaxCapacity)
 	} else {
-		assert.Equal(t, strings.Trim(queue.maxResource.String(), "map"), dao.Capacities.MaxCapacity)
+		assert.DeepEqual(t, queue.maxResource.DAOMap(), dao.Capacities.MaxCapacity)
 	}
 	if queue.guaranteedResource == nil {
-		assert.Equal(t, emptyRes, dao.Capacities.Capacity)
+		assert.DeepEqual(t, emptyRes, dao.Capacities.Capacity)
 	} else {
-		assert.Equal(t, strings.Trim(queue.guaranteedResource.String(), "map"), dao.Capacities.Capacity)
+		assert.DeepEqual(t, queue.guaranteedResource.DAOMap(), dao.Capacities.Capacity)
 	}
 	assert.Equal(t, len(queue.properties), len(dao.Properties))
 	if len(queue.properties) > 0 {
@@ -1364,14 +1363,14 @@ func TestGetPartitionQueueDAOInfo(t *testing.T) {
 	})
 	assert.NilError(t, err)
 	assert.Assert(t, reflect.DeepEqual(root.template.GetProperties(), root.GetPartitionQueueDAOInfo().TemplateInfo.Properties))
-	assert.Equal(t, root.template.GetMaxResource().DAOString(), root.template.GetMaxResource().DAOString())
-	assert.Equal(t, root.template.GetGuaranteedResource().DAOString(), root.template.GetGuaranteedResource().DAOString())
+	assert.DeepEqual(t, root.template.GetMaxResource().DAOMap(), root.template.GetMaxResource().DAOMap())
+	assert.DeepEqual(t, root.template.GetGuaranteedResource().DAOMap(), root.template.GetGuaranteedResource().DAOMap())
 
 	// test resources
 	root.maxResource = getResource(t)
 	root.guaranteedResource = getResource(t)
-	assert.Equal(t, root.GetMaxResource().DAOString(), root.GetMaxResource().DAOString())
-	assert.Equal(t, root.GetGuaranteedResource().DAOString(), root.GetGuaranteedResource().DAOString())
+	assert.DeepEqual(t, root.GetMaxResource().DAOMap(), root.GetMaxResource().DAOMap())
+	assert.DeepEqual(t, root.GetGuaranteedResource().DAOMap(), root.GetGuaranteedResource().DAOMap())
 }
 
 func getResourceConf() map[string]string {

--- a/pkg/scheduler/objects/template/template.go
+++ b/pkg/scheduler/objects/template/template.go
@@ -116,7 +116,7 @@ func (t *Template) GetTemplateInfo() *dao.TemplateInfo {
 	}
 	return &dao.TemplateInfo{
 		Properties:         t.GetProperties(),
-		MaxResource:        t.maxResource.DAOString(),
-		GuaranteedResource: t.guaranteedResource.DAOString(),
+		MaxResource:        t.maxResource.DAOMap(),
+		GuaranteedResource: t.guaranteedResource.DAOMap(),
 	}
 }

--- a/pkg/webservice/dao/application_info.go
+++ b/pkg/webservice/dao/application_info.go
@@ -24,8 +24,8 @@ type ApplicationsDAOInfo struct {
 
 type ApplicationDAOInfo struct {
 	ApplicationID   string              `json:"applicationID"`
-	UsedResource    string              `json:"usedResource"`
-	MaxUsedResource string              `json:"maxUsedResource"`
+	UsedResource    map[string]int64    `json:"usedResource"`
+	MaxUsedResource map[string]int64    `json:"maxUsedResource"`
 	Partition       string              `json:"partition"`
 	QueueName       string              `json:"queueName"`
 	SubmissionTime  int64               `json:"submissionTime"`
@@ -40,7 +40,7 @@ type AllocationDAOInfo struct {
 	AllocationKey    string            `json:"allocationKey"`
 	AllocationTags   map[string]string `json:"allocationTags"`
 	UUID             string            `json:"uuid"`
-	ResourcePerAlloc string            `json:"resource"`
+	ResourcePerAlloc map[string]int64  `json:"resource"`
 	Priority         string            `json:"priority"`
 	QueueName        string            `json:"queueName"`
 	NodeID           string            `json:"nodeId"`

--- a/pkg/webservice/dao/node_info.go
+++ b/pkg/webservice/dao/node_info.go
@@ -27,11 +27,11 @@ type NodeDAOInfo struct {
 	NodeID      string               `json:"nodeID"`
 	HostName    string               `json:"hostName"`
 	RackName    string               `json:"rackName"`
-	Capacity    string               `json:"capacity"`
-	Allocated   string               `json:"allocated"`
-	Occupied    string               `json:"occupied"`
-	Available   string               `json:"available"`
-	Utilized    string               `json:"utilized"`
+	Capacity    map[string]int64     `json:"capacity"`
+	Allocated   map[string]int64     `json:"allocated"`
+	Occupied    map[string]int64     `json:"occupied"`
+	Available   map[string]int64     `json:"available"`
+	Utilized    map[string]int64     `json:"utilized"`
 	Allocations []*AllocationDAOInfo `json:"allocations"`
 	Schedulable bool                 `json:"schedulable"`
 }

--- a/pkg/webservice/dao/partition_info.go
+++ b/pkg/webservice/dao/partition_info.go
@@ -35,9 +35,9 @@ type PartitionInfo struct {
 }
 
 type PartitionCapacity struct {
-	Capacity     string `json:"capacity"`
-	UsedCapacity string `json:"usedCapacity"`
-	Utilization  string `json:"utilization"`
+	Capacity     map[string]int64 `json:"capacity"`
+	UsedCapacity map[string]int64 `json:"usedCapacity"`
+	Utilization  map[string]int64 `json:"utilization"`
 }
 
 type NodeInfo struct {

--- a/pkg/webservice/dao/queue_info.go
+++ b/pkg/webservice/dao/queue_info.go
@@ -26,15 +26,15 @@ type QueueDAOInfo struct {
 }
 
 type QueueCapacity struct {
-	Capacity        string `json:"capacity"`
-	MaxCapacity     string `json:"maxCapacity"`
-	UsedCapacity    string `json:"usedCapacity"`
-	AbsUsedCapacity string `json:"absUsedCapacity"`
+	Capacity        map[string]int64 `json:"capacity"`
+	MaxCapacity     map[string]int64 `json:"maxCapacity"`
+	UsedCapacity    map[string]int64 `json:"usedCapacity"`
+	AbsUsedCapacity map[string]int64 `json:"absUsedCapacity"`
 }
 
 type TemplateInfo struct {
-	MaxResource        string            `json:"maxResource"`
-	GuaranteedResource string            `json:"guaranteedResource"`
+	MaxResource        map[string]int64  `json:"maxResource"`
+	GuaranteedResource map[string]int64  `json:"guaranteedResource"`
 	Properties         map[string]string `json:"properties"`
 }
 
@@ -42,14 +42,14 @@ type PartitionQueueDAOInfo struct {
 	QueueName          string                  `json:"queuename"`
 	Status             string                  `json:"status"`
 	Partition          string                  `json:"partition"`
-	MaxResource        string                  `json:"maxResource"`
-	GuaranteedResource string                  `json:"guaranteedResource"`
-	AllocatedResource  string                  `json:"allocatedResource"`
+	MaxResource        map[string]int64        `json:"maxResource"`
+	GuaranteedResource map[string]int64        `json:"guaranteedResource"`
+	AllocatedResource  map[string]int64        `json:"allocatedResource"`
 	IsLeaf             bool                    `json:"isLeaf"`
 	IsManaged          bool                    `json:"isManaged"`
 	Properties         map[string]string       `json:"properties"`
 	Parent             string                  `json:"parent"`
 	TemplateInfo       *TemplateInfo           `json:"template"`
 	Children           []PartitionQueueDAOInfo `json:"children"`
-	AbsUsedCapacity    string                  `json:"absUsedCapacity"`
+	AbsUsedCapacity    map[string]int64        `json:"absUsedCapacity"`
 }

--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -265,9 +265,12 @@ func getPartitionJSON(partition *scheduler.PartitionContext) *dao.PartitionDAOIn
 	queueDAOInfo := partition.GetQueueInfos()
 
 	partitionInfo.PartitionName = common.GetPartitionNameWithoutClusterID(partition.Name)
+	capacity := partition.GetTotalPartitionResource()
+	usedCapacity := partition.GetAllocatedResource()
 	partitionInfo.Capacity = dao.PartitionCapacity{
-		Capacity:     partition.GetTotalPartitionResource().DAOString(),
-		UsedCapacity: partition.GetAllocatedResource().DAOString(),
+		Capacity:     capacity.DAOMap(),
+		UsedCapacity: usedCapacity.DAOMap(),
+		Utilization:  resources.CalculateAbsUsedCapacity(capacity, usedCapacity).DAOMap(),
 	}
 	partitionInfo.Queues = queueDAOInfo
 
@@ -282,7 +285,7 @@ func getApplicationJSON(app *objects.Application) *dao.ApplicationDAOInfo {
 			AllocationKey:    alloc.AllocationKey,
 			AllocationTags:   alloc.Tags,
 			UUID:             alloc.UUID,
-			ResourcePerAlloc: alloc.AllocatedResource.DAOString(),
+			ResourcePerAlloc: alloc.AllocatedResource.DAOMap(),
 			Priority:         strconv.Itoa(int(alloc.Priority)),
 			QueueName:        alloc.QueueName,
 			NodeID:           alloc.NodeID,
@@ -294,8 +297,8 @@ func getApplicationJSON(app *objects.Application) *dao.ApplicationDAOInfo {
 
 	return &dao.ApplicationDAOInfo{
 		ApplicationID:   app.ApplicationID,
-		UsedResource:    app.GetAllocatedResource().DAOString(),
-		MaxUsedResource: app.GetMaxAllocatedResource().DAOString(),
+		UsedResource:    app.GetAllocatedResource().DAOMap(),
+		MaxUsedResource: app.GetMaxAllocatedResource().DAOMap(),
 		Partition:       common.GetPartitionNameWithoutClusterID(app.Partition),
 		QueueName:       app.QueuePath,
 		SubmissionTime:  app.SubmissionTime.UnixNano(),
@@ -315,7 +318,7 @@ func getNodeJSON(node *objects.Node) *dao.NodeDAOInfo {
 			AllocationKey:    alloc.AllocationKey,
 			AllocationTags:   alloc.Tags,
 			UUID:             alloc.UUID,
-			ResourcePerAlloc: alloc.AllocatedResource.DAOString(),
+			ResourcePerAlloc: alloc.AllocatedResource.DAOMap(),
 			Priority:         strconv.Itoa(int(alloc.Priority)),
 			QueueName:        alloc.QueueName,
 			NodeID:           alloc.NodeID,
@@ -329,11 +332,11 @@ func getNodeJSON(node *objects.Node) *dao.NodeDAOInfo {
 		NodeID:      node.NodeID,
 		HostName:    node.Hostname,
 		RackName:    node.Rackname,
-		Capacity:    node.GetCapacity().DAOString(),
-		Occupied:    node.GetOccupiedResource().DAOString(),
-		Allocated:   node.GetAllocatedResource().DAOString(),
-		Available:   node.GetAvailableResource().DAOString(),
-		Utilized:    node.GetUtilizedResource().DAOString(),
+		Capacity:    node.GetCapacity().DAOMap(),
+		Occupied:    node.GetOccupiedResource().DAOMap(),
+		Allocated:   node.GetAllocatedResource().DAOMap(),
+		Available:   node.GetAvailableResource().DAOMap(),
+		Utilized:    node.GetUtilizedResource().DAOMap(),
 		Allocations: allocations,
 		Schedulable: node.IsSchedulable(),
 	}
@@ -695,9 +698,9 @@ func getPartitionInfoDAO(lists map[string]*scheduler.PartitionContext) []*dao.Pa
 		capacityInfo := dao.PartitionCapacity{}
 		capacity := partitionContext.GetTotalPartitionResource()
 		usedCapacity := partitionContext.GetAllocatedResource()
-		capacityInfo.Capacity = capacity.DAOString()
-		capacityInfo.UsedCapacity = usedCapacity.DAOString()
-		capacityInfo.Utilization = resources.CalculateAbsUsedCapacity(capacity, usedCapacity).DAOString()
+		capacityInfo.Capacity = capacity.DAOMap()
+		capacityInfo.UsedCapacity = usedCapacity.DAOMap()
+		capacityInfo.Utilization = resources.CalculateAbsUsedCapacity(capacity, usedCapacity).DAOMap()
 		partitionInfo.Capacity = capacityInfo
 		partitionInfo.NodeSortingPolicy = dao.NodeSortingPolicy{
 			Type:            partitionContext.GetNodeSortingPolicyType().String(),

--- a/pkg/webservice/handlers_test.go
+++ b/pkg/webservice/handlers_test.go
@@ -463,7 +463,7 @@ func TestQueryParamInAppsHandler(t *testing.T) {
 	assert.Equal(t, len(appsDao), 2)
 	assert.Equal(t, appsDao[0].User, "abc")
 	assert.Assert(t, appsDao[0].FinishedTime == nil)
-	assert.Equal(t, appsDao[0].MaxUsedResource, "[vcore:1]")
+	assert.DeepEqual(t, appsDao[0].MaxUsedResource, map[string]int64{"vcore": 1})
 
 	assert.Equal(t, appsDao[1].RejectedMessage, rejectedMessage)
 	assert.Assert(t, appsDao[1].FinishedTime != nil)
@@ -923,9 +923,9 @@ func TestPartitions(t *testing.T) {
 	assert.Equal(t, cs["default"].Applications[objects.Rejected.String()], 1)
 	assert.Equal(t, cs["default"].Applications[objects.Completed.String()], 1)
 	assert.Equal(t, cs["default"].Applications[objects.Failed.String()], 1)
-	assert.Equal(t, cs["default"].Capacity.Capacity, "[memory:1000 vcore:1000]")
-	assert.Equal(t, cs["default"].Capacity.UsedCapacity, "[memory:300 vcore:700]")
-	assert.Equal(t, cs["default"].Capacity.Utilization, "[memory:30 vcore:70]")
+	assert.DeepEqual(t, cs["default"].Capacity.Capacity, map[string]int64{"memory": 1000, "vcore": 1000})
+	assert.DeepEqual(t, cs["default"].Capacity.UsedCapacity, map[string]int64{"memory": 300, "vcore": 700})
+	assert.DeepEqual(t, cs["default"].Capacity.Utilization, map[string]int64{"memory": 30, "vcore": 70})
 	assert.Equal(t, cs["default"].State, "Active")
 
 	assert.Assert(t, cs["gpu"] != nil)
@@ -1057,13 +1057,13 @@ func TestGetPartitionQueuesHandler(t *testing.T) {
 	maxResourcesConf["memory"] = "600000"
 	maxResource, err := resources.NewResourceFromConf(maxResourcesConf)
 	assert.NilError(t, err)
-	assert.Equal(t, partitionQueuesDao.TemplateInfo.MaxResource, maxResource.DAOString())
+	assert.DeepEqual(t, partitionQueuesDao.TemplateInfo.MaxResource, maxResource.DAOMap())
 
 	guaranteedResourcesConf := make(map[string]string)
 	guaranteedResourcesConf["memory"] = "400000"
 	guaranteedResources, err := resources.NewResourceFromConf(guaranteedResourcesConf)
 	assert.NilError(t, err)
-	assert.Equal(t, partitionQueuesDao.TemplateInfo.GuaranteedResource, guaranteedResources.DAOString())
+	assert.DeepEqual(t, partitionQueuesDao.TemplateInfo.GuaranteedResource, guaranteedResources.DAOMap())
 
 	// Partition not sent as part of request
 	req, err = http.NewRequest("GET", "/ws/v1/partition/default/queues", strings.NewReader(""))
@@ -1226,12 +1226,12 @@ func TestGetPartitionNodes(t *testing.T) {
 			assert.Equal(t, node.NodeID, node1ID)
 			assert.Equal(t, "alloc-1", node.Allocations[0].AllocationKey)
 			assert.Equal(t, "alloc-1-uuid", node.Allocations[0].UUID)
-			assert.Equal(t, "[memory:50 vcore:30]", node.Utilized)
+			assert.DeepEqual(t, map[string]int64{"memory": 50, "vcore": 30}, node.Utilized)
 		} else {
 			assert.Equal(t, node.NodeID, node2ID)
 			assert.Equal(t, "alloc-2", node.Allocations[0].AllocationKey)
 			assert.Equal(t, "alloc-2-uuid", node.Allocations[0].UUID)
-			assert.Equal(t, "[memory:30 vcore:50]", node.Utilized)
+			assert.DeepEqual(t, map[string]int64{"memory": 30, "vcore": 50}, node.Utilized)
 		}
 	}
 


### PR DESCRIPTION
### What is this PR for?
Currently, the REST API fields which represent collections of resources are currently returned as strings. This PR returns them as proper objects keyed by resource type and with int64 values.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-165

### How should this be tested?
Unit tests updated to reflect new usage.

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [x] - There is breaking changes for older versions.
* [x] - It needs documentation.
