### PR TITLE
[YUNIKORN-1077] Negative Container Count

### DIFF
--- a/pkg/scheduler/partition.go
+++ b/pkg/scheduler/partition.go
@@ -1363,11 +1363,18 @@ func (pc *PartitionContext) removeAllocation(release *si.AllocationRelease) ([]*
 	}
 	// if confirmed is set we can assume there will just be one alloc in the released
 	// that allocation was already released by the shim, so clean up released
+
 	if confirmed != nil {
 		released = nil
 	}
 	// track the number of allocations, when we replace the result is no change
 	pc.updateAllocationCount(-len(released))
+
+	// if the termination type is timeout, we don't notify the shim, because it's
+	// originated from that side
+	if release.TerminationType == si.TerminationType_TIMEOUT {
+		released = nil
+	}
 	return released, confirmed
 }
 

--- a/pkg/scheduler/partition_test.go
+++ b/pkg/scheduler/partition_test.go
@@ -1593,7 +1593,7 @@ func TestPlaceholderSmallerThanReal(t *testing.T) {
 		TerminationType: si.TerminationType_TIMEOUT,
 	}
 	released, _ := partition.removeAllocation(release)
-	assert.Equal(t, 1, len(released), "one allocation should be released")
+	assert.Equal(t, 0, len(released), "expected no releases")
 	assert.Assert(t, resources.IsZero(node.GetAllocatedResource()), "nothing should be allocated on node")
 	assert.Assert(t, resources.IsZero(app.GetQueue().GetAllocatedResource()), "nothing should be allocated on queue")
 	assert.Equal(t, 0, partition.GetTotalAllocationCount(), "no allocation should be registered on the partition")
@@ -1678,7 +1678,7 @@ func TestPlaceholderSmallerMulti(t *testing.T) {
 			TerminationType: si.TerminationType_TIMEOUT,
 		}
 		released, _ := partition.removeAllocation(release)
-		assert.Equal(t, 1, len(released), "one allocation should be released")
+		assert.Equal(t, 0, len(released), "expected no releases")
 	}
 	assert.Assert(t, resources.IsZero(node.GetAllocatedResource()), "nothing should be allocated on node")
 	assert.Assert(t, resources.IsZero(app.GetQueue().GetAllocatedResource()), "nothing should be allocated on queue")


### PR DESCRIPTION
### What is this PR for?
Sometimes the metrics for released and allocated containers are off - we have more released than allocated. This is because we don't process placeholder timeout events properly. 

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1077

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
